### PR TITLE
feat: Simple version endpoint.

### DIFF
--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -5,6 +5,7 @@ use tower_http::{cors::CorsLayer, trace::TraceLayer};
 pub fn create_app(state: AppState) -> Router {
     Router::new()
         .merge(routes::health::routes())
+        .merge(routes::version::routes())
         .layer(CorsLayer::permissive())
         .layer(TraceLayer::new_for_http())
         .with_state(state)

--- a/crates/server/src/handlers/mod.rs
+++ b/crates/server/src/handlers/mod.rs
@@ -1,1 +1,2 @@
 pub mod health;
+pub mod version;

--- a/crates/server/src/handlers/version/get_version.rs
+++ b/crates/server/src/handlers/version/get_version.rs
@@ -1,0 +1,15 @@
+use axum::{http::StatusCode, response::Json};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct VersionResponse {
+    pub version: String,
+}
+
+pub async fn get_version() -> (StatusCode, Json<VersionResponse>) {
+    let response = VersionResponse {
+        version: env!("CARGO_PKG_VERSION").to_string(),
+    };
+
+    (StatusCode::OK, Json(response))
+}

--- a/crates/server/src/handlers/version/mod.rs
+++ b/crates/server/src/handlers/version/mod.rs
@@ -1,0 +1,2 @@
+pub mod get_version;
+pub use get_version::get_version;

--- a/crates/server/src/routes/mod.rs
+++ b/crates/server/src/routes/mod.rs
@@ -1,1 +1,2 @@
 pub mod health;
+pub mod version;

--- a/crates/server/src/routes/version.rs
+++ b/crates/server/src/routes/version.rs
@@ -1,0 +1,7 @@
+use axum::{Router, routing::get};
+
+use crate::{handlers::version, state::AppState};
+
+pub fn routes() -> Router<AppState> {
+    Router::new().route("/version", get(version::get_version))
+}


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot-rest-api/issues/8

Can potentially be merged with the healthcheck, but at least this makes it clear that there is a call to get the version of the currently running node.