### PR TITLE
feat: Loki support for log aggregation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2292,6 +2292,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "loki-api"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdc38a304f59a03e6efa3876766a48c70a766a93f88341c3fff4212834b8e327"
+dependencies = [
+ "prost",
+ "prost-types",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2881,6 +2891,38 @@ dependencies = [
  "parking_lot",
  "protobuf",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost",
 ]
 
 [[package]]
@@ -3587,7 +3629,9 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-appender",
+ "tracing-loki",
  "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -3808,6 +3852,12 @@ dependencies = [
  "smoldot",
  "zeroize",
 ]
+
+[[package]]
+name = "snap"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
@@ -4872,6 +4922,27 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-loki"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3beec919fbdf99d719de8eda6adae3281f8a5b71ae40431f44dc7423053d34"
+dependencies = [
+ "loki-api",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "snap",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -69,6 +69,12 @@ struct EnvConfig {
     #[serde(default = "default_metrics_prometheus_prefix")]
     metrics_prometheus_prefix: String,
 
+    #[serde(default = "default_metrics_loki_host")]
+    metrics_loki_host: String,
+
+    #[serde(default = "default_metrics_loki_port")]
+    metrics_loki_port: u16,
+
     #[serde(default = "default_metrics_include_queryparams")]
     metrics_include_queryparams: bool,
 }
@@ -141,6 +147,14 @@ fn default_metrics_prometheus_prefix() -> String {
     "polkadot_rest_api".to_string()
 }
 
+fn default_metrics_loki_host() -> String {
+    "127.0.0.1".to_string()
+}
+
+fn default_metrics_loki_port() -> u16 {
+    3100
+}
+
 fn default_metrics_include_queryparams() -> bool {
     false
 }
@@ -175,6 +189,8 @@ impl SidecarConfig {
     /// - SAS_METRICS_PROM_HOST
     /// - SAS_METRICS_PROM_PORT
     /// - SAS_METRICS_PROMETHEUS_PREFIX
+    /// - SAS_METRICS_LOKI_HOST
+    /// - SAS_METRICS_LOKI_PORT
     /// - SAS_METRICS_INCLUDE_QUERYPARAMS
     pub fn from_env() -> Result<Self, ConfigError> {
         // Load flat env config
@@ -213,6 +229,8 @@ impl SidecarConfig {
                 prom_host: env_config.metrics_prom_host,
                 prom_port: env_config.metrics_prom_port,
                 prometheus_prefix: env_config.metrics_prometheus_prefix,
+                loki_host: env_config.metrics_loki_host,
+                loki_port: env_config.metrics_loki_port,
                 include_queryparams: env_config.metrics_include_queryparams,
             },
         };

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -34,6 +34,8 @@ scale-value = "0.18"
 prometheus = "0.13"
 lazy_static = "1.4"
 regex = "1.10"
+tracing-loki = "0.2"
+url = "2.5"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/server/src/logging.rs
+++ b/crates/server/src/logging.rs
@@ -14,45 +14,85 @@ pub enum LoggingError {
 
     #[error("Failed to create log directory or file appender: {0}")]
     IoError(#[from] std::io::Error),
+
+    #[error("Failed to parse Loki URL '{url}': {source}")]
+    InvalidLokiUrl {
+        url: String,
+        #[source]
+        source: url::ParseError,
+    },
+
+    #[error("Failed to configure Loki integration: {0}")]
+    LokiError(#[from] tracing_loki::Error),
 }
 
-/// Initialize tracing/logging with the specified level and format
+/// Configuration for logging initialization
+pub struct LoggingConfig<'a> {
+    pub level: &'a str,
+    pub json_format: bool,
+    pub strip_ansi: bool,
+    pub write_to_file: bool,
+    pub write_path: &'a str,
+    pub write_max_file_size: u64,
+    pub write_max_files: usize,
+    pub loki_url: Option<&'a str>,
+}
+
+/// Initialize tracing/logging with the specified configuration
 ///
 /// # Arguments
-/// * `level` - Log level (trace, debug, info, warn, error)
-/// * `json_format` - If true, output logs in JSON format
-/// * `strip_ansi` - If true, disable ANSI color codes in logs
-/// * `write_to_file` - If true, write logs to a file with size-based rotation
-/// * `write_path` - Directory path to write log files
-/// * `write_max_file_size` - Maximum file size in bytes before rotation
-/// * `write_max_files` - Maximum number of rotated files to keep
+/// * `config` - LoggingConfig struct containing all logging parameters
 ///
 /// # Examples
 /// ```no_run
-/// use server::logging;
+/// use server::logging::{self, LoggingConfig};
 ///
 /// // Console only
-/// logging::init("debug", false, false, false, "./logs", 5242880, 5)?;
+/// logging::init_with_config(LoggingConfig {
+///     level: "debug",
+///     json_format: false,
+///     strip_ansi: false,
+///     write_to_file: false,
+///     write_path: "./logs",
+///     write_max_file_size: 5242880,
+///     write_max_files: 5,
+///     loki_url: None,
+/// })?;
 ///
-/// // JSON + file with 5MB rotation, 5 files
-/// logging::init("info", true, false, true, "./logs", 5242880, 5)?;
+/// // With Loki logging (sends logs to Loki aggregation server)
+/// logging::init_with_config(LoggingConfig {
+///     level: "info",
+///     json_format: true,
+///     strip_ansi: false,
+///     write_to_file: true,
+///     write_path: "./logs",
+///     write_max_file_size: 5242880,
+///     write_max_files: 5,
+///     loki_url: Some("http://localhost:3100"),
+/// })?;
 /// # Ok::<(), server::logging::LoggingError>(())
 /// ```
+///
+/// # Loki Integration
+/// When a Loki URL is provided, logs are sent asynchronously to the Loki server
+/// with the following default labels:
+/// - `service`: "polkadot-rest-api"
+/// - `pid`: Current process ID
 ///
 /// # Log Rotation
 /// When a log file reaches `write_max_file_size`, it is rotated:
 /// - Current: logs.log
 /// - After rotation: logs.log.1, logs.log.2, etc.
 /// - Keeps up to `write_max_files` rotated files
-pub fn init(
-    level: &str,
-    json_format: bool,
-    strip_ansi: bool,
-    write_to_file: bool,
-    write_path: &str,
-    write_max_file_size: u64,
-    write_max_files: usize,
-) -> Result<(), LoggingError> {
+pub fn init_with_config(config: LoggingConfig) -> Result<(), LoggingError> {
+    let level = config.level;
+    let json_format = config.json_format;
+    let strip_ansi = config.strip_ansi;
+    let write_to_file = config.write_to_file;
+    let write_path = config.write_path;
+    let write_max_file_size = config.write_max_file_size;
+    let write_max_files = config.write_max_files;
+    let loki_url = config.loki_url;
     // Create filter from level
     let filter = EnvFilter::try_new(level).map_err(|source| LoggingError::InvalidLogLevel {
         level: level.to_string(),
@@ -61,6 +101,27 @@ pub fn init(
 
     // Build the subscriber based on config
     let registry = tracing_subscriber::registry();
+
+    // Create Loki layer if URL is provided
+    let loki_layer = if let Some(url) = loki_url {
+        let parsed_url = url::Url::parse(url).map_err(|source| LoggingError::InvalidLokiUrl {
+            url: url.to_string(),
+            source,
+        })?;
+
+        // Create Loki layer with default labels
+        let (loki_layer, task) = tracing_loki::builder()
+            .label("service", "polkadot-rest-api")?
+            .extra_field("pid", format!("{}", std::process::id()))?
+            .build_url(parsed_url)?;
+
+        // Spawn the Loki task to send logs in the background
+        tokio::spawn(task);
+
+        Some(loki_layer)
+    } else {
+        None
+    };
 
     if write_to_file {
         // Ensure log directory exists
@@ -88,11 +149,20 @@ pub fn init(
             let console_layer = fmt::layer().json();
             let file_layer = fmt::layer().json().with_writer(non_blocking);
 
-            registry
-                .with(filter)
-                .with(console_layer)
-                .with(file_layer)
-                .init();
+            if let Some(loki) = loki_layer {
+                registry
+                    .with(filter)
+                    .with(console_layer)
+                    .with(file_layer)
+                    .with(loki)
+                    .init();
+            } else {
+                registry
+                    .with(filter)
+                    .with(console_layer)
+                    .with(file_layer)
+                    .init();
+            }
         } else {
             // Human-readable format for both console and file
             let console_layer = fmt::layer()
@@ -110,17 +180,30 @@ pub fn init(
                 .with_ansi(false) // Never use ANSI in files
                 .with_writer(non_blocking);
 
-            registry
-                .with(filter)
-                .with(console_layer)
-                .with(file_layer)
-                .init();
+            if let Some(loki) = loki_layer {
+                registry
+                    .with(filter)
+                    .with(console_layer)
+                    .with(file_layer)
+                    .with(loki)
+                    .init();
+            } else {
+                registry
+                    .with(filter)
+                    .with(console_layer)
+                    .with(file_layer)
+                    .init();
+            }
         }
     } else {
         // Console output only
         if json_format {
             let fmt_layer = fmt::layer().json();
-            registry.with(filter).with(fmt_layer).init();
+            if let Some(loki) = loki_layer {
+                registry.with(filter).with(fmt_layer).with(loki).init();
+            } else {
+                registry.with(filter).with(fmt_layer).init();
+            }
         } else {
             let fmt_layer = fmt::layer()
                 .with_target(true)
@@ -129,9 +212,39 @@ pub fn init(
                 .with_line_number(true)
                 .with_ansi(!strip_ansi);
 
-            registry.with(filter).with(fmt_layer).init();
+            if let Some(loki) = loki_layer {
+                registry.with(filter).with(fmt_layer).with(loki).init();
+            } else {
+                registry.with(filter).with(fmt_layer).init();
+            }
         }
     }
 
     Ok(())
+}
+
+/// Initialize tracing/logging (legacy function - prefer init_with_config)
+///
+/// This function is provided for backward compatibility. New code should use `init_with_config`.
+#[allow(clippy::too_many_arguments)]
+pub fn init(
+    level: &str,
+    json_format: bool,
+    strip_ansi: bool,
+    write_to_file: bool,
+    write_path: &str,
+    write_max_file_size: u64,
+    write_max_files: usize,
+    loki_url: Option<&str>,
+) -> Result<(), LoggingError> {
+    init_with_config(LoggingConfig {
+        level,
+        json_format,
+        strip_ansi,
+        write_to_file,
+        write_path,
+        write_max_file_size,
+        write_max_files,
+        loki_url,
+    })
 }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -39,6 +39,15 @@ async fn main() -> Result<(), MainError> {
     let metrics_host = state.config.metrics.prom_host.clone();
     let metrics_port = state.config.metrics.prom_port;
     let metrics_prefix = state.config.metrics.prometheus_prefix.clone();
+    let loki_host = state.config.metrics.loki_host.clone();
+    let loki_port = state.config.metrics.loki_port;
+
+    // Build Loki URL if metrics are enabled (Loki is part of metrics/observability stack)
+    let loki_url = if metrics_enabled {
+        Some(format!("http://{}:{}", loki_host, loki_port))
+    } else {
+        None
+    };
 
     logging::init(
         &log_level,
@@ -48,6 +57,7 @@ async fn main() -> Result<(), MainError> {
         &log_write_path,
         log_write_max_file_size,
         log_write_max_files,
+        loki_url.as_deref(),
     )?;
 
     // Parse bind_host to IpAddr


### PR DESCRIPTION
Add Loki support to match Sidecar functionality

Closes https://github.com/paritytech/polkadot-rest-api/issues/29 as it adds the final

- SAS_METRICS_LOKI_HOST
- SAS_METRICS_LOKI_PORT