### PR TITLE
fix: ensure empty arrays stay as empty arrays

### DIFF
--- a/crates/server/src/handlers/blocks/get_block.rs
+++ b/crates/server/src/handlers/blocks/get_block.rs
@@ -465,10 +465,11 @@ fn convert_bytes_to_hex(value: Value) -> Value {
         Value::Array(arr) => {
             // Check if this is a byte array (non-empty and all elements are numbers 0-255)
             // We must check !arr.is_empty() to avoid converting empty arrays to "0x"
-            let is_byte_array = !arr.is_empty() && arr.iter().all(|v| match v {
-                Value::Number(n) => n.as_u64().is_some_and(|val| val <= 255),
-                _ => false,
-            });
+            let is_byte_array = !arr.is_empty()
+                && arr.iter().all(|v| match v {
+                    Value::Number(n) => n.as_u64().is_some_and(|val| val <= 255),
+                    _ => false,
+                });
 
             if is_byte_array {
                 // Convert to hex string


### PR DESCRIPTION
Small fix for historic data where paraInclusion may have empty head data. The previous behavior was returning a '0x' for an empty array which is invalid but instead we should return an empty array.

Before this PR goes in let's wait for https://github.com/paritytech/polkadot-rest-api/pull/52 to go in.