### PR TITLE
fix: digest log format to match substrate-api-sidecar and restore author extraction

### DIFF
--- a/crates/server/src/handlers/blocks/get_block.rs
+++ b/crates/server/src/handlers/blocks/get_block.rs
@@ -1562,10 +1562,10 @@ mod tests {
         // Verify logs are decoded
         assert_eq!(response.logs.len(), 1);
         assert_eq!(response.logs[0].log_type, "PreRuntime");
-        assert_eq!(response.logs[0].index, 0);
-        // Verify the engine ID is "BABE" and payload is present
+        assert_eq!(response.logs[0].index, "6"); // PreRuntime discriminant
+        // Verify the engine ID is hex-encoded and payload is present
         if let Some(arr) = response.logs[0].value.as_array() {
-            assert_eq!(arr[0].as_str(), Some("BABE"));
+            assert_eq!(arr[0].as_str(), Some("0x42414245")); // "BABE" in hex
             assert!(arr[1].as_str().unwrap().starts_with("0x"));
         } else {
             panic!("Expected PreRuntime log value to be an array");


### PR DESCRIPTION
 # Summary

Fixes digest log format to match substrate-api-sidecar's structured format (hex-encoded engine IDs, string index values, proper SCALE decoding) and restores author extraction that was broken by the format changes.
 
 ## Changes 
  
- Changed DigestLog.index type: Changed from u32 to String to match substrate-api-sidecar format ("6" instead of 6)
- Engine ID encoding: Changed consensus engine IDs from UTF-8 strings ("BABE") to hex-encoded format ("0x42414245")
- Index value source: Use SCALE discriminant byte as index value instead of array position (e.g., PreRuntime uses 6,
   Seal uses 5)
- SCALE decoding: Properly decode consensus digest structure as (ConsensusEngineId, Vec<u8>) where:
    - First 4 bytes: raw engine ID (no length prefix)
    - Remaining bytes: SCALE-encoded Vec<u8> (compact length + data
- Engine ID comparison: Added hex::decode() to convert hex-encoded engine IDs ("0x42414245") back to bytes before
  comparing with BABE_ENGINE, AURA_ENGINE, and POW_ENGINE constants
- Payload decoding: Removed incorrect compact length skip - the payload is already decoded from SCALE format in
  decode_consensus_digest, so we can decode PreDigest directly
- Applied to both code paths: Fixed both PreRuntime logs (BABE/Aura) and Consensus logs (PoW)