### PR TITLE
fix: add success and paysFee fields to extrinsics

### DIFF
--- a/crates/server/src/handlers/blocks/get_block.rs
+++ b/crates/server/src/handlers/blocks/get_block.rs
@@ -235,7 +235,7 @@ pub struct SignatureInfo {
 #[serde(rename_all = "camelCase")]
 pub struct ExtrinsicInfo {
     pub method: MethodInfo,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Signature information - null for unsigned extrinsics (inherents)
     pub signature: Option<SignatureInfo>,
     /// Nonce - shown as null when extraction fails (matching sidecar behavior)
     pub nonce: Option<String>,


### PR DESCRIPTION
  Adds two new fields to the /blocks/{blockId} endpoint response to match substrate-api-sidecar:

  - success: bool - Determined from System.ExtrinsicSuccess/ExtrinsicFailed events
  - paysFee: bool - Extracted from DispatchInfo in success/failed events (only for signed extrinsics; unsigned always
  return false)

  Also ensures signature: null is serialized for unsigned extrinsics instead of omitting the field.