### PR TITLE
test: add output per integration test that completes

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,16 +82,50 @@ cargo run --release --bin polkadot-rest-api
 # Run all integration tests
 cargo test --package integration_tests
 
-# Run tests for a specific chain
-cargo test --package integration_tests test_latest_polkadot
-cargo test --package integration_tests test_latest_kusama
-cargo test --package integration_tests test_historical_polkadot
-cargo test --package integration_tests test_historical_kusama
-cargo test --package integration_tests test_historical_asset_hub_polkadot
-cargo test --package integration_tests test_historical_asset_hub_kusama
+# Run a specific test suite (recommended - cleaner output)
+cargo test --package integration_tests --test historical  # All historical tests
+cargo test --package integration_tests --test latest      # All latest tests
+cargo test --package integration_tests --test basic       # All basic tests
+```
 
-# Run basic endpoint tests (chain-agnostic)
-cargo test --package integration_tests --test basic
+**Running tests for a specific chain:**
+
+```bash
+# Historical tests (use fixtures for regression testing)
+cargo test --package integration_tests --test historical test_historical_polkadot
+cargo test --package integration_tests --test historical test_historical_kusama
+cargo test --package integration_tests --test historical test_historical_asset_hub_polkadot
+cargo test --package integration_tests --test historical test_historical_asset_hub_kusama
+
+# Latest tests (test against live blockchain data)
+cargo test --package integration_tests --test latest test_latest_polkadot
+cargo test --package integration_tests --test latest test_latest_kusama
+cargo test --package integration_tests --test latest test_latest_asset_hub_polkadot
+cargo test --package integration_tests --test latest test_latest_asset_hub_kusama
+```
+
+**Viewing test output:**
+
+By default, cargo captures test output. To see the detailed test progress with checkmarks and colored output, add `-- --nocapture`:
+
+```bash
+cargo test --package integration_tests --test historical test_historical_polkadot -- --nocapture
+```
+
+Example output:
+```
+Running 2 historical test cases for chain: polkadot
+
+✓ /v1/blocks/{blockId} (block 1000000)
+✓ /v1/blocks/{blockId} (block 10000000)
+
+════════════════════════════════════════════════════════════
+Historical Test Results for polkadot
+════════════════════════════════════════════════════════════
+  ✓ Passed: 2
+  ✗ Failed: 0
+════════════════════════════════════════════════════════════
+```
 
 ### Updating Test Fixtures
 

--- a/crates/integration_tests/README.md
+++ b/crates/integration_tests/README.md
@@ -1,0 +1,208 @@
+# Integration Tests
+
+This crate contains integration tests for the Polkadot REST API.
+
+## Test Suites
+
+### 1. Basic Tests (`tests/basic.rs`)
+
+Smoke tests for fundamental API endpoints. These are chain-agnostic and verify basic functionality.
+
+- Health endpoint validation
+- Version endpoint validation
+- Error handling for invalid endpoints
+- Concurrent request handling
+
+### 2. Latest Tests (`tests/latest.rs`)
+
+Tests that run against the current/latest blockchain data. These verify that endpoints work correctly with live data.
+
+- Tests configured endpoints from `test_config.json`
+- Fetches the latest block number dynamically
+- Validates HTTP status codes
+
+### 3. Historical Tests (`tests/historical.rs`)
+
+Regression tests using pre-recorded fixtures. These ensure API responses remain consistent across code changes.
+
+- Compares API responses against stored JSON fixtures
+- Tests specific historical blocks (e.g., block 1,000,000)
+- Ignores time-varying fields (timestamps, etc.)
+
+## Running Tests
+
+### Prerequisites
+
+Start the API server connected to the appropriate chain:
+
+```bash
+# For Polkadot
+export SAS_SUBSTRATE_URL=wss://rpc.polkadot.io
+cargo run --release --bin polkadot-rest-api
+
+# For Kusama
+export SAS_SUBSTRATE_URL=wss://kusama-rpc.polkadot.io
+cargo run --release --bin polkadot-rest-api
+```
+
+### Run Commands
+
+```bash
+# Run all tests in a suite (recommended)
+cargo test --package integration_tests --test historical
+cargo test --package integration_tests --test latest
+cargo test --package integration_tests --test basic
+
+# Run a specific chain's tests
+cargo test --package integration_tests --test historical test_historical_polkadot
+cargo test --package integration_tests --test latest test_latest_polkadot
+
+# View detailed output with progress indicators
+cargo test --package integration_tests --test historical test_historical_polkadot -- --nocapture
+```
+
+### Understanding the Output
+
+With `--nocapture`, tests display progress as they run:
+
+```
+Running 2 historical test cases for chain: polkadot
+
+✓ /v1/blocks/{blockId} (block 1000000)
+✓ /v1/blocks/{blockId} (block 10000000)
+
+════════════════════════════════════════════════════════════
+Historical Test Results for polkadot
+════════════════════════════════════════════════════════════
+  ✓ Passed: 2
+  ✗ Failed: 0
+════════════════════════════════════════════════════════════
+```
+
+## Configuration
+
+### Test Configuration (`tests/config/test_config.json`)
+
+Defines chains, endpoints, and test cases:
+
+```json
+{
+  "chains": [
+    { "name": "polkadot", "api_url": "http://localhost:8080" }
+  ],
+  "latest_endpoints": [
+    { "path": "/v1/health", "query_params": [{}] }
+  ],
+  "historical_tests": {
+    "polkadot": [
+      {
+        "endpoint": "/v1/blocks/{blockId}",
+        "block_height": 1000000,
+        "fixture_path": "polkadot/blocks_1000000.json"
+      }
+    ]
+  }
+}
+```
+
+### Fixtures (`tests/fixtures/`)
+
+Pre-recorded JSON responses organized by chain:
+
+```
+tests/fixtures/
+├── polkadot/
+│   ├── blocks_1000000.json
+│   └── blocks_10000000.json
+├── kusama/
+│   └── blocks_5000000.json
+├── asset-hub-polkadot/
+│   ├── blocks_10250000_pre_migration.json
+│   └── blocks_10260000_post_migration.json
+└── asset-hub-kusama/
+    ├── blocks_11150000_pre_migration.json
+    └── blocks_11152000_post_migration.json
+```
+
+## Adding New Tests
+
+### Adding a Latest Endpoint Test
+
+1. Add the endpoint to `latest_endpoints` in `test_config.json`:
+
+```json
+{
+  "path": "/v1/runtime/metadata",
+  "query_params": [{}],
+  "requires_block_height": false,
+  "requires_account": false
+}
+```
+
+### Adding a Historical Test
+
+1. Add the test case to `historical_tests` in `test_config.json`:
+
+```json
+{
+  "endpoint": "/v1/runtime/spec",
+  "block_height": 1000000,
+  "fixture_path": "polkadot/runtime_spec_1000000.json",
+  "description": "Test runtime spec at block 1,000,000"
+}
+```
+
+2. Generate the fixture:
+
+```bash
+# Start server connected to the chain
+cargo run --release --bin polkadot-rest-api
+
+# Run the fixture update tool
+cargo run --bin update_fixtures -- polkadot
+```
+
+Or manually create the fixture by calling the endpoint and saving the response.
+
+## Updating Fixtures
+
+When API responses change intentionally, update fixtures:
+
+```bash
+# Update all fixtures
+cargo run --bin update_fixtures
+
+# Update fixtures for a specific chain
+cargo run --bin update_fixtures -- polkadot
+cargo run --bin update_fixtures -- kusama
+```
+
+Or use the convenience script:
+
+```bash
+./scripts/update_fixtures.sh
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `API_URL` | `http://localhost:8080` | Base URL of the API server |
+| `TEST_CONFIG_PATH` | `tests/config/test_config.json` | Path to test configuration |
+| `FIXTURES_DIR` | `tests/fixtures` | Path to fixture files |
+| `RUST_LOG` | - | Log level (e.g., `info`, `debug`) |
+
+## JSON Comparison
+
+The historical tests use a sophisticated JSON comparison system that:
+
+- Recursively compares nested objects and arrays
+- Ignores specified fields (e.g., `timestamp`, `at`)
+- Reports detailed diffs with colored output
+- Handles extra/missing fields gracefully
+
+Ignored fields in historical tests:
+- `timestamp`
+- `at`
+- `blockNumber`
+- `blockHash`

--- a/crates/integration_tests/tests/historical.rs
+++ b/crates/integration_tests/tests/historical.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
-use futures::future::join_all;
+use colored::Colorize;
+use futures::stream::{FuturesUnordered, StreamExt};
 use integration_tests::{
     client::TestClient, config::TestConfig, constants::API_READY_TIMEOUT_SECONDS,
     fixtures::FixtureLoader, utils::compare_json,
@@ -33,15 +34,17 @@ impl HistoricalTestRunner {
     /// Run all historical tests for the configured chain
     async fn run_all(&self) -> Result<TestResults> {
         let test_cases = self.config.get_historical_tests(&self.chain_name);
+        let total_tests = test_cases.len();
 
-        tracing::info!(
-            "Running {} historical test cases for chain: {}",
-            test_cases.len(),
-            self.chain_name
+        println!(
+            "\n{} {} historical test cases for chain: {}\n",
+            "Running".cyan().bold(),
+            total_tests,
+            self.chain_name.yellow()
         );
 
-        // Create futures for parallel execution
-        let futures: Vec<_> = test_cases
+        // Create FuturesUnordered for streaming results as they complete
+        let mut futures: FuturesUnordered<_> = test_cases
             .iter()
             .map(|test_case| async move {
                 let result = self.run_test_case(test_case).await;
@@ -49,16 +52,19 @@ impl HistoricalTestRunner {
             })
             .collect();
 
-        // Execute all tests in parallel
-        let all_results = join_all(futures).await;
-
-        // Aggregate results
+        // Process results as they complete
         let mut results = TestResults::default();
-        for (test_case, result) in all_results {
+        while let Some((test_case, result)) = futures.next().await {
+            let test_name = if let Some(block_height) = test_case.block_height {
+                format!("{} (block {})", test_case.endpoint, block_height)
+            } else {
+                test_case.endpoint.clone()
+            };
+
             match result {
                 Ok(()) => {
                     results.passed += 1;
-                    tracing::info!("✓ Test passed: {}", test_case.endpoint);
+                    println!("{} {}", "✓".green().bold(), test_name);
                 }
                 Err(e) => {
                     results.failed += 1;
@@ -67,7 +73,7 @@ impl HistoricalTestRunner {
                         description: test_case.description.clone(),
                         error: format!("{:?}", e),
                     });
-                    tracing::error!("✗ Test failed: {} - {}", test_case.endpoint, e);
+                    println!("{} {} - {}", "✗".red().bold(), test_name, e);
                 }
             }
         }
@@ -176,18 +182,31 @@ async fn run_historical_test_for_chain(chain_name: &str) -> Result<()> {
     let runner = HistoricalTestRunner::new(client, config, fixture_loader, chain_name.to_string());
     let results = runner.run_all().await?;
 
-    println!("\n=== Historical Test Results for {} ===", chain_name);
-    println!("Passed: {}", results.passed);
-    println!("Failed: {}", results.failed);
+    println!("\n{}", "═".repeat(60).bright_white());
+    println!("Historical Test Results for {}", chain_name.yellow().bold());
+    println!("{}", "═".repeat(60).bright_white());
+    println!(
+        "  {} Passed: {}",
+        "✓".green().bold(),
+        results.passed.to_string().green()
+    );
+    println!(
+        "  {} Failed: {}",
+        "✗".red().bold(),
+        results.failed.to_string().red()
+    );
+    println!("{}\n", "═".repeat(60).bright_white());
 
     if !results.failures.is_empty() {
-        println!("\nFailures:");
+        println!("{}", "Failures:".red().bold());
         for failure in &results.failures {
-            println!("  - {}: {}", failure.endpoint, failure.error);
+            println!("  {} {}", "•".red(), failure.endpoint);
+            println!("    {}: {}", "Error".red(), failure.error);
             if let Some(ref desc) = failure.description {
-                println!("    Description: {}", desc);
+                println!("    {}: {}", "Description".yellow(), desc);
             }
         }
+        println!();
     }
 
     assert_eq!(results.failed, 0, "{} test(s) failed", results.failed);


### PR DESCRIPTION
  Adds real-time progress indicators and formatted summaries to integration tests.

  ### Example output

  Running 2 historical test cases for chain: polkadot

  ✓ /v1/blocks/{blockId} (block 1000000)
  ✓ /v1/blocks/{blockId} (block 10000000)

  ════════════════════════════════════════════════════════════
  Historical Test Results for polkadot
  ════════════════════════════════════════════════════════════
    ✓ Passed: 2
    ✗ Failed: 0
  ════════════════════════════════════════════════════════════

  ### Usage

  ```bash
  cargo test --package integration_tests --test historical test_historical_polkadot -- --nocapture