### PR TITLE
feat: add `noFees` query param to /blocks/*

### DIFF
--- a/crates/server/src/handlers/blocks/types.rs
+++ b/crates/server/src/handlers/blocks/types.rs
@@ -31,6 +31,9 @@ pub struct BlockQueryParams {
     /// When true, include documentation for extrinsics
     #[serde(default)]
     pub extrinsic_docs: bool,
+    /// When true, skip fee calculation for extrinsics (info will be empty object)
+    #[serde(default)]
+    pub no_fees: bool,
 }
 
 // ================================================================================================


### PR DESCRIPTION
  Adds `noFees` query parameter to `/blocks/{blockId}` endpoint.

  ### Changes

  - Added `no_fees` field to `BlockQueryParams` in `types.rs`
  - Skip fee calculation when `noFees=true` in `get_block.rs`

  ### Usage

  - `GET /blocks/123` → fees calculated (default)
  - `GET /blocks/123?noFees=true` → fees skipped, `info: {}`
  
  rel: https://github.com/paritytech/polkadot-rest-api/issues/25