### PR TITLE
feat: add `finalizedKey` to `/blocks/{blockId}`

### DIFF
--- a/crates/server/src/handlers/blocks/types.rs
+++ b/crates/server/src/handlers/blocks/types.rs
@@ -22,7 +22,7 @@ pub const CONSENSUS_ENGINE_ID_LEN: usize = 4;
 // ================================================================================================
 
 /// Query parameters for /blocks/{blockId} endpoint
-#[derive(Debug, Deserialize, Default)]
+#[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BlockQueryParams {
     /// When true, include documentation for events
@@ -34,6 +34,24 @@ pub struct BlockQueryParams {
     /// When true, skip fee calculation for extrinsics (info will be empty object)
     #[serde(default)]
     pub no_fees: bool,
+    /// When true, include finalized status in response. When false, omit finalized field.
+    #[serde(default = "default_true")]
+    pub finalized_key: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for BlockQueryParams {
+    fn default() -> Self {
+        Self {
+            event_docs: false,
+            extrinsic_docs: false,
+            no_fees: false,
+            finalized_key: true,
+        }
+    }
 }
 
 // ================================================================================================
@@ -301,8 +319,9 @@ pub struct BlockResponse {
     pub on_initialize: OnInitialize,
     pub extrinsics: Vec<ExtrinsicInfo>,
     pub on_finalize: OnFinalize,
-    /// Whether this block has been finalized
-    pub finalized: bool,
+    /// Whether this block has been finalized (omitted when finalizedKey=false)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finalized: Option<bool>,
 }
 
 // ================================================================================================


### PR DESCRIPTION
  Adds `finalizedKey` query parameter to `/blocks/{blockId}` endpoint.

  ### Changes

  - Added `finalized_key` field to `BlockQueryParams` (default: `true`)
  - Changed `BlockResponse.finalized` to `Option<bool>` to support omitting the field
  - Skip finalization RPC calls when `finalizedKey=false`

  ### Usage

  - `GET /blocks/123` → includes `"finalized": true/false`
  - `GET /blocks/123?finalizedKey=false` → omits `finalized` field (performance optimization)
  
  rel: https://github.com/paritytech/polkadot-rest-api/issues/25