### PR TITLE
feat: add /runtime/spec fixtures for Kusama and Asset Hubs

### DIFF
--- a/crates/integration_tests/tests/config/test_config.json
+++ b/crates/integration_tests/tests/config/test_config.json
@@ -97,6 +97,14 @@
     ],
     "kusama": [
       {
+        "endpoint": "/v1/runtime/spec",
+        "block_height": null,
+        "account_id": null,
+        "query_params": { "at": "5000000" },
+        "fixture_path": "kusama/runtime_spec_5000000.json",
+        "description": "Test runtime spec at Kusama block 5,000,000"
+      },
+      {
         "endpoint": "/v1/blocks/{blockId}",
         "block_height": 5000000,
         "account_id": null,
@@ -106,6 +114,14 @@
       }
     ],
     "asset-hub-polkadot": [
+      {
+        "endpoint": "/v1/runtime/spec",
+        "block_height": null,
+        "account_id": null,
+        "query_params": { "at": "10260000" },
+        "fixture_path": "asset-hub-polkadot/runtime_spec_10260000.json",
+        "description": "Test runtime spec at Asset Hub Polkadot block 10,260,000"
+      },
       {
         "endpoint": "/v1/blocks/{blockId}",
         "block_height": 10250000,
@@ -124,6 +140,14 @@
       }
     ],
     "asset-hub-kusama": [
+      {
+        "endpoint": "/v1/runtime/spec",
+        "block_height": null,
+        "account_id": null,
+        "query_params": { "at": "11152000" },
+        "fixture_path": "asset-hub-kusama/runtime_spec_11152000.json",
+        "description": "Test runtime spec at Asset Hub Kusama block 11,152,000"
+      },
       {
         "endpoint": "/v1/blocks/{blockId}",
         "block_height": 11150000,

--- a/crates/integration_tests/tests/fixtures/asset-hub-kusama/runtime_spec_11152000.json
+++ b/crates/integration_tests/tests/fixtures/asset-hub-kusama/runtime_spec_11152000.json
@@ -1,0 +1,24 @@
+{
+	"at": {
+		"height": "11152000",
+		"hash": "0x70c613cd0258cf801515f7b7f3e4bd9f00d1c597aa62a51b9b777528b284962f"
+	},
+	"authoringVersion": "1",
+	"transactionVersion": "15",
+	"implVersion": "0",
+	"specName": "statemine",
+	"specVersion": "1009001",
+	"chainType": {
+		"live": null
+	},
+	"properties": {
+		"isEthereum": false,
+		"ss58Format": "2",
+		"tokenDecimals": [
+			"12"
+		],
+		"tokenSymbol": [
+			"KSM"
+		]
+	}
+}

--- a/crates/integration_tests/tests/fixtures/asset-hub-polkadot/runtime_spec_10260000.json
+++ b/crates/integration_tests/tests/fixtures/asset-hub-polkadot/runtime_spec_10260000.json
@@ -1,0 +1,24 @@
+{
+	"at": {
+		"height": "10260000",
+		"hash": "0xec77b29816dec211e0565fdbdee1e29a7fc482f6f19e6e44ecdebc37545a155e"
+	},
+	"authoringVersion": "1",
+	"transactionVersion": "15",
+	"implVersion": "0",
+	"specName": "statemint",
+	"specVersion": "2000000",
+	"chainType": {
+		"live": null
+	},
+	"properties": {
+		"isEthereum": false,
+		"ss58Format": "0",
+		"tokenDecimals": [
+			"10"
+		],
+		"tokenSymbol": [
+			"DOT"
+		]
+	}
+}

--- a/crates/integration_tests/tests/fixtures/kusama/runtime_spec_5000000.json
+++ b/crates/integration_tests/tests/fixtures/kusama/runtime_spec_5000000.json
@@ -1,0 +1,24 @@
+{
+	"at": {
+		"height": "5000000",
+		"hash": "0xe360cc614f6de435a6e1e2598795aca7ca9dfc658b84ecf8e7139b89d7a161e3"
+	},
+	"authoringVersion": "2",
+	"transactionVersion": "3",
+	"implVersion": "0",
+	"specName": "kusama",
+	"specVersion": "2026",
+	"chainType": {
+		"live": null
+	},
+	"properties": {
+		"isEthereum": false,
+		"ss58Format": "2",
+		"tokenDecimals": [
+			"12"
+		],
+		"tokenSymbol": [
+			"KSM"
+		]
+	}
+}


### PR DESCRIPTION
This PR adds runtime spec fixtures for Kusama and Asset Hub chains to enable integration testing across multiple  networks.

## Changes Made
**Runtime Spec Fixtures**
- Added Kusama fixture at block 5,000,000
  - Spec version 2026, transaction version 3
  - KSM token with 12 decimals, SS58 format 2

- Added Asset Hub Polkadot fixture at block 10,260,000
  - Spec name "statemint", spec version 2,000,000
  - DOT token with 10 decimals, SS58 format 0
  - Post-migration era (after migration ended at 10,259,208)

- Added Asset Hub Kusama fixture at block 11,152,000 
  - Spec name "statemine", spec version 1,009,001
  - KSM token with 12 decimals, SS58 format 2
  - Post-migration era (after migration ended at 11,151,931)

**Test Configuration**
- Updated test_config.json with new chain entries:
  - kusama: /v1/runtime/spec endpoint with at=5000000
  - asset-hub-polkadot: /v1/runtime/spec endpoint with at=10260000
  - asset-hub-kusama: /v1/runtime/spec endpoint with at=11152000