### PR TITLE
fix: Allow hostnames in config validation for loki addresses + adding Loki to docker compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ If needed, the login and password for grafana are set to "admin" and "admin" res
 
 Prometheus is accessible at http://localhost:9090/
 
+Loki logs can be viewed in Grafana at Explore > Loki (select Loki as the datasource and query with `{service_name="polkadot-rest-api"}`)
+
 ## Benchmarks
 
 ### Benchmark Workflows

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,8 +20,17 @@ services:
       SAS_SUBSTRATE_URL: ws://polkadot:9944
       # SAS_SUBSTRATE_URL: wss://rpc.polkadot.io
       SAS_METRICS_ENABLED: "true"
+      SAS_METRICS_LOKI_HOST: loki
     depends_on:
       - polkadot
+      - loki
+
+  loki:
+    container_name: loki
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yaml
 
   prometheus:
     container_name: prometheus

--- a/metrics/grafana/provisioning/datasources/datasources.yml
+++ b/metrics/grafana/provisioning/datasources/datasources.yml
@@ -7,3 +7,8 @@ datasources:
     url: http://prometheus:9090
     isDefault: true
     editable: false
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false


### PR DESCRIPTION
Also adding Loki to docker compose setup.

Loki is assumed to be enabled when metrics are enabled. This is matching behavior from Sidecar. In the future it will likely make sense to have Loki be optionally toggled.

Addresses the 2nd issue mentioned in https://github.com/paritytech/polkadot-rest-api/pull/96
```
ERROR tracing_loki: /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-loki-0.2.6/src/lib.rs:537: couldn't send logs to loki error_count=6 backoff_time=8s error=error sending request for url (http://127.0.0.1:3100/loki/api/v1/push)
```