### PR TITLE
fix: Fix middleware so the response_size_bytes metric is populated

### DIFF
--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -42,6 +42,7 @@ lazy_static = "1.4"
 regex = "1.10"
 tracing-loki = "0.2"
 url = "2.5"
+http-body-util = "0.1"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }


### PR DESCRIPTION
Add wrapping of response body so we can count bytes.

This does buffer the requests to momory, which should be fine but could be problematic for large requests. We should stream the data through but I think it adds more complexity than it is worth, and that we should only address it if it becomes an issue.