### PR TITLE
feat: Add container metrics to the supplied grafana dashboard.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,13 @@ When running locally with `docker compose`, the Grafana dashboard is accessible 
 
 If needed, the login and password for grafana are set to "admin" and "admin" respectfully.
 
+All container resources are shown despite only the `rest-api` container being useful.
+To map the short ids for a container name you can run
+
+```bash
+docker ps --format '{{.ID}}: {{.Names}}'
+```
+
 Prometheus is accessible at http://localhost:9090/
 
 Loki logs can be viewed in Grafana at Explore > Loki (select Loki as the datasource and query with `{service_name="polkadot-rest-api"}`)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,17 @@ services:
       - "3100:3100"
     command: -config.file=/etc/loki/local-config.yaml
 
+  cadvisor:
+    container_name: cadvisor
+    image: gcr.io/cadvisor/cadvisor:latest
+    privileged: true
+    ports:
+      - "8081:8080"
+    volumes:
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+
   prometheus:
     container_name: prometheus
     image: prom/prometheus:latest
@@ -44,6 +55,7 @@ services:
       - "--storage.tsdb.path=/prometheus"
     depends_on:
       - rest-api
+      - cadvisor
 
   grafana:
     container_name: grafana

--- a/metrics/grafana/provisioning/dashboards/polkadot-rest-api.json
+++ b/metrics/grafana/provisioning/dashboards/polkadot-rest-api.json
@@ -493,6 +493,191 @@
       ],
       "title": "P95 Latency by Route",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      },
+      "id": 9,
+      "panels": [],
+      "title": "Container Resources",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "label_replace(sum(rate(container_cpu_usage_seconds_total{id=~\"/system.slice/docker-.*\"}[5m])) by (id), \"container\", \"$1\", \"id\", \"/system.slice/docker-([a-f0-9]{12}).*\")",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "CPU Usage",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "expr": "label_replace(container_memory_working_set_bytes{id=~\"/system.slice/docker-.*\"}, \"container\", \"$1\", \"id\", \"/system.slice/docker-([a-f0-9]{12}).*\")",
+          "legendFormat": "{{container}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Memory Usage",
+      "type": "timeseries"
     }
   ],
   "refresh": "5s",

--- a/metrics/prometheus.yml
+++ b/metrics/prometheus.yml
@@ -7,3 +7,7 @@ scrape_configs:
     static_configs:
       - targets: ["rest-api:8080"]
     metrics_path: /metrics
+
+  - job_name: "cadvisor"
+    static_configs:
+      - targets: ["cadvisor:8080"]


### PR DESCRIPTION
We show all resources for all containers as it is difficult to map the container ids to the services that we are concerned about. In order to map, you can run

```bash
docker ps --format '{{.ID}}: {{.Names}}'
```

<img width="2474" height="480" alt="image" src="https://github.com/user-attachments/assets/a3a9949b-1c85-4d07-8b37-af91cbc478ba" />
