### PR TITLE
fix: remove logging from on_going_referenda

### DIFF
--- a/crates/server/src/handlers/pallets/on_going_referenda.rs
+++ b/crates/server/src/handlers/pallets/on_going_referenda.rs
@@ -215,10 +215,7 @@ async fn fetch_ongoing_referenda(
     let count_addr = subxt::dynamic::storage::<(), u32>("Referenda", "ReferendumCount");
     let referendum_count: u32 = match client_at_block.storage().fetch(count_addr, ()).await {
         Ok(storage_val) => match storage_val.decode() {
-            Ok(count) => {
-                tracing::info!("Successfully decoded ReferendumCount: {}", count);
-                count
-            }
+            Ok(count) => count,
             Err(e) => {
                 tracing::warn!("Failed to decode ReferendumCount: {:?}", e);
                 return Err(PalletError::StorageDecodeFailed {
@@ -266,8 +263,6 @@ async fn fetch_ongoing_referenda(
             }
         }
     };
-
-    tracing::info!("ReferendumCount: {}", referendum_count);
 
     // Iterate in batches from highest ID to lowest (ongoing referenda are usually recent)
     // Use concurrent requests for better performance
@@ -319,12 +314,6 @@ async fn fetch_ongoing_referenda(
 
         id -= batch_size as i64;
     }
-
-    tracing::info!(
-        "Found {} ongoing referenda out of {} total",
-        referenda.len(),
-        referendum_count
-    );
 
     // Sort by ID in descending order to match Sidecar's ordering (highest ID first)
     referenda.sort_by(|a, b| {


### PR DESCRIPTION
### Description
- Removed 3 unnecessary `tracing::info!` calls in `on_going_referenda.rs`.

### Reproduce
- In one terminal run 
  - `export SAS_SUBSTRATE_URL=wss://rpc.polkadot.io` 
  - `cargo run --release --bin polkadot-rest-api`

- In a second terminal run `cargo test --package integration_tests --test historical` which results in the following logging in the first terminal:
    ```bash
    2026-02-09T15:02:17.698167Z  INFO server::handlers::pallets::on_going_referenda: crates/server/src/handlers/pallets/on_going_referenda.rs:219: Successfully decoded ReferendumCount: 1473
    2026-02-09T15:02:17.698205Z  INFO server::handlers::pallets::on_going_referenda: crates/server/src/handlers/pallets/on_going_referenda.rs:270: ReferendumCount: 1473
    2026-02-09T15:02:18.961908Z  INFO server::handlers::pallets::on_going_referenda: crates/server/src/handlers/pallets/on_going_referenda.rs:219: Successfully decoded ReferendumCount: 1366
    2026-02-09T15:02:18.961950Z  INFO server::handlers::pallets::on_going_referenda: crates/server/src/handlers/pallets/on_going_referenda.rs:270: ReferendumCount: 1366
    2026-02-09T15:02:19.453351Z  INFO server::handlers::pallets::on_going_referenda: crates/server/src/handlers/pallets/on_going_referenda.rs:323: Found 3 ongoing referenda out of 1473 total
    2026-02-09T15:02:20.645847Z  INFO server::handlers::pallets::on_going_referenda: crates/server/src/handlers/pallets/on_going_referenda.rs:323: Found 3 ongoing referenda out of 1366 total
    ```