### PR TITLE
fix: address diff mismatches from #208

### DIFF
--- a/crates/server/src/handlers/common/accounts/balance_info.rs
+++ b/crates/server/src/handlers/common/accounts/balance_info.rs
@@ -202,7 +202,6 @@ pub async fn query_balance_info(
     // Fetch existential deposit from runtime constants (sync - reads from metadata)
     let existential_deposit = fetch_existential_deposit(client_at_block)?;
 
-    // Query System::Account and Balances::Locks concurrently
     let (account_data_result, locks_result) = tokio::join!(
         query_account_data(client_at_block, account),
         query_balance_locks(client_at_block, account)


### PR DESCRIPTION
## Summary

  Fixes two field mismatches in `/accounts/{accountId}/balance-info` response compared to Substrate API Sidecar:

  - **`transferable`**: Now fetches `ExistentialDeposit` dynamically from runtime constants instead of using hardcoded values. This fixes incorrect calculations on Asset Hub where ED differs from the relay chain.
  - **`locks[].id`**: Changed format from decoded UTF-8 string to hex with `0x` prefix to match Sidecar output.

  Also adds a minor optimization by running account data and balance locks queries concurrently.
  
  closes: https://github.com/paritytech/polkadot-rest-api/issues/208