### PR TITLE
fix: use correct SS58 prefix for proxy delegate addresses

### DIFF
--- a/crates/server/src/handlers/accounts/get_proxy_info.rs
+++ b/crates/server/src/handlers/accounts/get_proxy_info.rs
@@ -64,7 +64,13 @@ pub async fn get_proxy_info(
     let resolved_block = utils::resolve_block(&state, block_id).await?;
     let client_at_block = state.client.at_block(resolved_block.number).await?;
 
-    let raw_info = query_proxy_info(&client_at_block, &account, &resolved_block).await?;
+    let raw_info = query_proxy_info(
+        &client_at_block,
+        &account,
+        &resolved_block,
+        state.chain_info.ss58_prefix,
+    )
+    .await?;
 
     let response = format_response(&raw_info, None, None, None);
 
@@ -151,7 +157,13 @@ async fn handle_use_rc_block(
             number: ah_block.number,
         };
         let client_at_block = state.client.at_block(ah_resolved.number).await?;
-        let raw_info = query_proxy_info(&client_at_block, &account, &ah_resolved).await?;
+        let raw_info = query_proxy_info(
+            &client_at_block,
+            &account,
+            &ah_resolved,
+            state.chain_info.ss58_prefix,
+        )
+        .await?;
 
         let response = format_response(
             &raw_info,

--- a/crates/server/src/handlers/rc/accounts/get_proxy_info.rs
+++ b/crates/server/src/handlers/rc/accounts/get_proxy_info.rs
@@ -64,7 +64,8 @@ pub async fn get_proxy_info(
         utils::resolve_block_with_rpc(rc_rpc_client, rc_rpc.as_ref(), block_id).await?;
     let client_at_block = rc_client.at_block(resolved_block.number).await?;
 
-    let raw_info = query_proxy_info(&client_at_block, &account, &resolved_block).await?;
+    let raw_info =
+        query_proxy_info(&client_at_block, &account, &resolved_block, rc_ss58_prefix).await?;
 
     let response = format_response(&raw_info);
 


### PR DESCRIPTION
## Summary

  Fixes SS58 encoding for delegate addresses in `/accounts/{accountId}/proxy-info` and `/rc/accounts/{accountId}/proxy-info` endpoints.

  Previously, delegate addresses were encoded with the generic Substrate prefix (42). Now uses the chain's actual SS58 prefix, so relay chain queries return Polkadot-formatted addresses (prefix 0).
  
  closes: https://github.com/paritytech/polkadot-rest-api/issues/211