### PR TITLE
fix: return JSON error for missing required query parameters

### DIFF
--- a/crates/integration_tests/tests/accounts/asset_approvals.rs
+++ b/crates/integration_tests/tests/accounts/asset_approvals.rs
@@ -264,44 +264,92 @@ async fn test_asset_approvals_missing_required_params() -> Result<()> {
     );
     println!("{}", "═".repeat(80).bright_white());
 
-    // Test missing assetId
+    // Test missing both assetId and delegate
+    let endpoint_no_params = format!("/accounts/{}/asset-approvals", account_id);
+    let (status_both, json_both) = local_client
+        .get_json(&format!("/v1{}", endpoint_no_params))
+        .await
+        .context("Failed to fetch from local API")?;
+
+    assert_eq!(
+        status_both.as_u16(),
+        400,
+        "Expected 400 Bad Request for missing both params"
+    );
+    let error_both = json_both
+        .as_object()
+        .and_then(|o| o.get("error"))
+        .and_then(|e| e.as_str())
+        .expect("Response should have an 'error' string field");
+    assert!(
+        error_both.contains("assetId") && error_both.contains("delegate"),
+        "Error should mention both missing fields, got: {}",
+        error_both
+    );
+    println!(
+        "{} Missing both params returns 400: {}",
+        "✓".green(),
+        error_both
+    );
+
+    // Test missing assetId only
     let endpoint_no_asset = format!(
         "/accounts/{}/asset-approvals?delegate=15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5",
         account_id
     );
-    let response_no_asset = local_client
-        .get(&format!("/v1{}", endpoint_no_asset))
+    let (status_no_asset, json_no_asset) = local_client
+        .get_json(&format!("/v1{}", endpoint_no_asset))
         .await
         .context("Failed to fetch from local API")?;
 
     assert_eq!(
-        response_no_asset.status.as_u16(),
+        status_no_asset.as_u16(),
         400,
         "Expected 400 Bad Request for missing assetId"
     );
+    let error_no_asset = json_no_asset
+        .as_object()
+        .and_then(|o| o.get("error"))
+        .and_then(|e| e.as_str())
+        .expect("Response should have an 'error' string field");
     assert!(
-        response_no_asset.body.contains("assetId"),
-        "Error message should mention missing assetId"
+        error_no_asset.contains("assetId"),
+        "Error should mention missing assetId, got: {}",
+        error_no_asset
     );
-    println!("{} Missing assetId returns 400", "✓".green());
+    println!(
+        "{} Missing assetId returns 400: {}",
+        "✓".green(),
+        error_no_asset
+    );
 
-    // Test missing delegate
+    // Test missing delegate only
     let endpoint_no_delegate = format!("/accounts/{}/asset-approvals?assetId=1984", account_id);
-    let response_no_delegate = local_client
-        .get(&format!("/v1{}", endpoint_no_delegate))
+    let (status_no_delegate, json_no_delegate) = local_client
+        .get_json(&format!("/v1{}", endpoint_no_delegate))
         .await
         .context("Failed to fetch from local API")?;
 
     assert_eq!(
-        response_no_delegate.status.as_u16(),
+        status_no_delegate.as_u16(),
         400,
         "Expected 400 Bad Request for missing delegate"
     );
+    let error_no_delegate = json_no_delegate
+        .as_object()
+        .and_then(|o| o.get("error"))
+        .and_then(|e| e.as_str())
+        .expect("Response should have an 'error' string field");
     assert!(
-        response_no_delegate.body.contains("delegate"),
-        "Error message should mention missing delegate"
+        error_no_delegate.contains("delegate"),
+        "Error should mention missing delegate, got: {}",
+        error_no_delegate
     );
-    println!("{} Missing delegate returns 400", "✓".green());
+    println!(
+        "{} Missing delegate returns 400: {}",
+        "✓".green(),
+        error_no_delegate
+    );
 
     println!(
         "{} Required parameter validation passed!",

--- a/crates/integration_tests/tests/accounts/pool_asset_approvals.rs
+++ b/crates/integration_tests/tests/accounts/pool_asset_approvals.rs
@@ -240,44 +240,92 @@ async fn test_pool_asset_approvals_missing_required_params() -> Result<()> {
     );
     println!("{}", "═".repeat(80).bright_white());
 
-    // Test missing assetId
+    // Test missing both assetId and delegate
+    let endpoint_no_params = format!("/accounts/{}/pool-asset-approvals", account_id);
+    let (status_both, json_both) = local_client
+        .get_json(&format!("/v1{}", endpoint_no_params))
+        .await
+        .context("Failed to fetch from local API")?;
+
+    assert_eq!(
+        status_both.as_u16(),
+        400,
+        "Expected 400 Bad Request for missing both params"
+    );
+    let error_both = json_both
+        .as_object()
+        .and_then(|o| o.get("error"))
+        .and_then(|e| e.as_str())
+        .expect("Response should have an 'error' string field");
+    assert!(
+        error_both.contains("assetId") && error_both.contains("delegate"),
+        "Error should mention both missing fields, got: {}",
+        error_both
+    );
+    println!(
+        "{} Missing both params returns 400: {}",
+        "✓".green(),
+        error_both
+    );
+
+    // Test missing assetId only
     let endpoint_no_asset = format!(
         "/accounts/{}/pool-asset-approvals?delegate=15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5",
         account_id
     );
-    let response_no_asset = local_client
-        .get(&format!("/v1{}", endpoint_no_asset))
+    let (status_no_asset, json_no_asset) = local_client
+        .get_json(&format!("/v1{}", endpoint_no_asset))
         .await
         .context("Failed to fetch from local API")?;
 
     assert_eq!(
-        response_no_asset.status.as_u16(),
+        status_no_asset.as_u16(),
         400,
         "Expected 400 for missing assetId"
     );
+    let error_no_asset = json_no_asset
+        .as_object()
+        .and_then(|o| o.get("error"))
+        .and_then(|e| e.as_str())
+        .expect("Response should have an 'error' string field");
     assert!(
-        response_no_asset.body.contains("assetId"),
-        "Should mention missing assetId"
+        error_no_asset.contains("assetId"),
+        "Error should mention missing assetId, got: {}",
+        error_no_asset
     );
-    println!("{} Missing assetId returns 400", "✓".green());
+    println!(
+        "{} Missing assetId returns 400: {}",
+        "✓".green(),
+        error_no_asset
+    );
 
-    // Test missing delegate
+    // Test missing delegate only
     let endpoint_no_delegate = format!("/accounts/{}/pool-asset-approvals?assetId=0", account_id);
-    let response_no_delegate = local_client
-        .get(&format!("/v1{}", endpoint_no_delegate))
+    let (status_no_delegate, json_no_delegate) = local_client
+        .get_json(&format!("/v1{}", endpoint_no_delegate))
         .await
         .context("Failed to fetch from local API")?;
 
     assert_eq!(
-        response_no_delegate.status.as_u16(),
+        status_no_delegate.as_u16(),
         400,
         "Expected 400 for missing delegate"
     );
+    let error_no_delegate = json_no_delegate
+        .as_object()
+        .and_then(|o| o.get("error"))
+        .and_then(|e| e.as_str())
+        .expect("Response should have an 'error' string field");
     assert!(
-        response_no_delegate.body.contains("delegate"),
-        "Should mention missing delegate"
+        error_no_delegate.contains("delegate"),
+        "Error should mention missing delegate, got: {}",
+        error_no_delegate
     );
-    println!("{} Missing delegate returns 400", "✓".green());
+    println!(
+        "{} Missing delegate returns 400: {}",
+        "✓".green(),
+        error_no_delegate
+    );
 
     println!(
         "{} Required parameter validation passed!",

--- a/crates/server/src/handlers/accounts/get_pool_asset_approvals.rs
+++ b/crates/server/src/handlers/accounts/get_pool_asset_approvals.rs
@@ -10,7 +10,7 @@ use crate::state::AppState;
 use crate::utils::{self, fetch_block_timestamp, find_ah_blocks_in_rc_block};
 use axum::{
     Json,
-    extract::{Path, Query, State},
+    extract::{Path, Query, State, rejection::QueryRejection},
     response::{IntoResponse, Response},
 };
 use config::ChainType;
@@ -65,8 +65,26 @@ struct PoolAssetApproval {
 pub async fn get_pool_asset_approvals(
     State(state): State<AppState>,
     Path(account_id): Path<String>,
-    Query(params): Query<PoolAssetApprovalQueryParams>,
+    uri: axum::http::Uri,
+    query: Result<Query<PoolAssetApprovalQueryParams>, QueryRejection>,
 ) -> Result<Response, AccountsError> {
+    let Query(params) = query.map_err(|_| {
+        let qs = uri.query().unwrap_or("");
+        let has_asset_id = qs.contains("assetId=");
+        let has_delegate = qs.contains("delegate=");
+        match (has_asset_id, has_delegate) {
+            (false, false) => AccountsError::MissingQueryParam(
+                "Missing required query parameters: 'assetId', 'delegate'",
+            ),
+            (false, true) => {
+                AccountsError::MissingQueryParam("Missing required query parameter: 'assetId'")
+            }
+            (true, false) => {
+                AccountsError::MissingQueryParam("Missing required query parameter: 'delegate'")
+            }
+            _ => AccountsError::MissingQueryParam("Invalid query parameters"),
+        }
+    })?;
     let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
 
     let delegate = validate_and_parse_address(&params.delegate, state.chain_info.ss58_prefix)

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -277,6 +277,10 @@ pub enum AccountsError {
     #[error("Invalid foreign asset multilocation: {0}")]
     InvalidForeignAsset(String),
 
+    // ---- Query parameter errors ----
+    #[error("{0}")]
+    MissingQueryParam(&'static str),
+
     // ---- Generic internal error ----
     #[error("Internal error: {0}")]
     InternalError(String),
@@ -363,6 +367,7 @@ impl_error_response!(AccountsError,
     AccountsError::TooManyAddresses => BAD_REQUEST,
     AccountsError::NoAddresses => BAD_REQUEST,
     AccountsError::InvalidForeignAsset(_) => BAD_REQUEST,
+    AccountsError::MissingQueryParam(_) => BAD_REQUEST,
     _ => INTERNAL_SERVER_ERROR
 );
 


### PR DESCRIPTION
## Description
Endpoints `asset-approvals` and `pool-asset-approvals` are returning a plain text error message instead of the standard JSON error format when required query parameters are missing.

### Example
In Polkadot Asset Hub when querying 

```bash
/accounts/16AExTwdZnzJ4UDM1MeQ3cNuetTtFz1yrpYTaVqCNJtmeppK/asset-approvals?at=6463882
```
the error message is a plain text
```
Failed to deserialize query string: missing field `assetId`
```

_SideNote_
_The example request with all required query params would be_
```
 /accounts/16AExTwdZnzJ4UDM1MeQ3cNuetTtFz1yrpYTaVqCNJtmeppK/asset-approvals?at=6463882&delegate=1571AZEVkiXnzjHsjqfw2m65uuvjtyQUJ19uwukcdv9h8YZ2&assetId=1984
```
_which works as expected_

### Suggested Changes
With the changes in this PR, the error now is in the standard JSON format and it is specific to which fields are missing:
- Both missing: `{"error": "Missing required query parameters: 'assetId', 'delegate'" }`
- Only assetId: `{"error": "Missing required query parameter: 'assetId'"}`
- Only delegate: `{"error": "Missing required query parameter: 'delegate'"}`



## Testing
Updated tests for both `asset-approvals` and `pool-asset-approvals`