### PR TITLE
fix: expand complex type definitions in args field

### DIFF
--- a/crates/server/src/handlers/pallets/events.rs
+++ b/crates/server/src/handlers/pallets/events.rs
@@ -10,7 +10,7 @@
 
 use crate::handlers::pallets::common::{
     AtResponse, PalletError, PalletItemQueryParams, PalletQueryParams, RcBlockFields,
-    RcPalletItemQueryParams, RcPalletQueryParams, resolve_block_for_pallet, resolve_type_name,
+    RcPalletItemQueryParams, RcPalletQueryParams, expand_type_definition, resolve_block_for_pallet,
 };
 use crate::state::AppState;
 use crate::utils;
@@ -395,7 +395,7 @@ fn extract_events_from_metadata(
                             let args: Vec<String> = variant
                                 .fields
                                 .iter()
-                                .map(|f| resolve_type_name(types, f.ty.id))
+                                .map(|f| expand_type_definition(types, f.ty.id))
                                 .collect();
 
                             EventItemMetadata {
@@ -474,7 +474,7 @@ fn extract_event_item_from_metadata(
         let args: Vec<String> = event_variant
             .fields
             .iter()
-            .map(|f| resolve_type_name(types, f.ty.id))
+            .map(|f| expand_type_definition(types, f.ty.id))
             .collect();
 
         Some(EventItemMetadata {

--- a/docs/guides/MIGRATION.md
+++ b/docs/guides/MIGRATION.md
@@ -31,6 +31,7 @@ Update all client URLs by prepending `/v1` to existing paths.
 - **Numeric fields**: All u16 and u32 fields are now returned as numbers instead of strings. This is an intentional divergence to provide more accurate JSON types, while maintaining safety for large values (u128 is still returned as a string).
 - **HTTP status codes**: Error responses (e.g., pallet missing at a requested block) now return 400 or 404 instead of 500.
 - **Price fix**: `/v1/coretime/info` — The `currentCorePrice` calculation has been corrected. The previous calculation was faulty. See [PR #175](https://github.com/paritytech/polkadot-rest-api/pull/175).
+- **Field name**: In events endpoint, `args` type definitions, struct fields with `_alias` metadata (e.g., `hash_` aliased to `hash`) return the serialized name directly
 
 ### Query parameter changes
 


### PR DESCRIPTION
This PR fixes a divergence where REST-API returned simplified type names in the args field of event metadata, while Sidecar returns fully expanded type definitions.

**Changes Made**
- Recursively expands complex types (structs, enums) into JSON-like string format
- Handles framework types (sp_*, frame_*) by converting to PascalCase path names
- Special handling for Option<T>, Result<T,E>, Vec<u8> (Bytes)
- Preserves well-known types like AccountId32, H256, Vote without expansion
- Includes depth limit to prevent infinite recursion on self-referential types
- Changed args field generation from resolve_type_name() to expand_type_definition()
- Applied to both extract_events_from_metadata and extract_event_item_from_metadata

Testing
All unit tests pass (396 tests)
Historical integration tests validated

Resolves:
https://github.com/paritytech/polkadot-rest-api/issues/212