### PR TITLE
fix: fix response format for staking-info

### DIFF
--- a/crates/server/src/handlers/accounts/get_staking_info.rs
+++ b/crates/server/src/handlers/accounts/get_staking_info.rs
@@ -93,10 +93,16 @@ fn format_response(
     ah_timestamp: Option<String>,
 ) -> StakingInfoResponse {
     let reward_destination = match &raw.reward_destination {
-        DecodedRewardDestination::Simple(name) => RewardDestination::Simple(name.clone()),
-        DecodedRewardDestination::Account { account } => RewardDestination::Account {
-            account: account.clone(),
+        DecodedRewardDestination::Simple(name) => match name.as_str() {
+            "Staked" => RewardDestination::Staked(()),
+            "Stash" => RewardDestination::Stash(()),
+            "Controller" => RewardDestination::Controller(()),
+            "None" => RewardDestination::None(()),
+            _ => RewardDestination::Staked(()),
         },
+        DecodedRewardDestination::Account { account } => {
+            RewardDestination::Account(account.clone())
+        }
     };
 
     let nominations = raw.nominations.as_ref().map(|n| NominationsInfo {
@@ -142,7 +148,7 @@ fn format_response(
         },
         controller: raw.controller.clone(),
         reward_destination,
-        num_slashing_spans: raw.num_slashing_spans,
+        num_slashing_spans: raw.num_slashing_spans.to_string(),
         nominations,
         staking,
         rc_block_hash,

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -690,10 +690,9 @@ pub struct StakingInfoResponse {
     pub reward_destination: RewardDestination,
 
     /// Number of slashing spans
-    pub num_slashing_spans: u32,
+    pub num_slashing_spans: String,
 
     /// Nomination info (null if not a nominator)
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub nominations: Option<NominationsInfo>,
 
     /// Staking ledger information
@@ -708,14 +707,20 @@ pub struct StakingInfoResponse {
     pub ah_timestamp: Option<String>,
 }
 
-/// Reward destination - can be "Staked", "Stash", "Controller", or { "account": "..." }
+/// Reward destination - e.g. { "staked": null }, { "stash": null }, { "account": "..." }
 #[derive(Debug, Serialize, ToSchema)]
-#[serde(untagged)]
+#[serde(rename_all = "camelCase")]
 pub enum RewardDestination {
-    /// Simple variant without account (Staked, Stash, Controller, None)
-    Simple(String),
-    /// Account variant with specific address
-    Account { account: String },
+    /// Rewards are automatically re-staked
+    Staked(()),
+    /// Rewards are sent to the stash account
+    Stash(()),
+    /// Rewards are sent to the controller account
+    Controller(()),
+    /// No reward destination
+    None(()),
+    /// Rewards are sent to a specific account
+    Account(String),
 }
 
 /// Nominations information for a nominator

--- a/crates/server/src/handlers/rc/accounts/get_staking_info.rs
+++ b/crates/server/src/handlers/rc/accounts/get_staking_info.rs
@@ -137,10 +137,16 @@ fn get_relay_chain_access(state: &AppState) -> Result<RelayChainAccess<'_>, Acco
 
 fn format_response(raw: &RawStakingInfo) -> RcStakingInfoResponse {
     let reward_destination = match &raw.reward_destination {
-        DecodedRewardDestination::Simple(name) => RewardDestination::Simple(name.clone()),
-        DecodedRewardDestination::Account { account } => RewardDestination::Account {
-            account: account.clone(),
+        DecodedRewardDestination::Simple(name) => match name.as_str() {
+            "Staked" => RewardDestination::Staked(()),
+            "Stash" => RewardDestination::Stash(()),
+            "Controller" => RewardDestination::Controller(()),
+            "None" => RewardDestination::None(()),
+            _ => RewardDestination::Staked(()),
         },
+        DecodedRewardDestination::Account { account } => {
+            RewardDestination::Account(account.clone())
+        }
     };
 
     let nominations = raw.nominations.as_ref().map(|n| NominationsInfo {
@@ -186,7 +192,7 @@ fn format_response(raw: &RawStakingInfo) -> RcStakingInfoResponse {
         },
         controller: raw.controller.clone(),
         reward_destination,
-        num_slashing_spans: raw.num_slashing_spans,
+        num_slashing_spans: raw.num_slashing_spans.to_string(),
         nominations,
         staking,
     }

--- a/crates/server/src/handlers/rc/accounts/types.rs
+++ b/crates/server/src/handlers/rc/accounts/types.rs
@@ -168,10 +168,9 @@ pub struct RcStakingInfoResponse {
     pub reward_destination: RewardDestination,
 
     /// Number of slashing spans
-    pub num_slashing_spans: u32,
+    pub num_slashing_spans: String,
 
-    /// Nominations info (None if not a nominator)
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Nominations info (null if not a nominator)
     pub nominations: Option<NominationsInfo>,
 
     /// Staking ledger


### PR DESCRIPTION
closes #217 

in accounts/:accountId/staking-info the PR fixes the formatting of empty nominations to null, the format of numSlashingSpans to string and rewardDestination to object