### PR TITLE
fix: Update migration guide with response differences

### DIFF
--- a/docs/guides/MIGRATION.md
+++ b/docs/guides/MIGRATION.md
@@ -75,6 +75,45 @@ Both return an array of Asset Hub blocks (or `[]` if none found).
 
 ---
 
+### Response Differences
+
+#### Pallet metadata `args` field — simplified type names
+
+The `args` field in pallet metadata responses (e.g., `/v1/pallets/{palletId}/events`, `/v1/pallets/{palletId}/errors`) returns **simplified type names** instead of fully expanded type definitions. This applies to any endpoint that exposes type arguments for pallet items.
+
+#### Example Responses
+
+**Polkadot REST API:**
+```json
+{
+  "args": ["DispatchInfo"]
+}
+```
+```json
+{
+  "args": ["DispatchError", "DispatchInfo"]
+}
+```
+
+**Sidecar (expanded definitions):**
+```json
+{
+  "args": ["{\"weight\":\"SpWeightsWeightV2Weight\",\"class\":\"FrameSupportDispatchDispatchClass\",\"paysFee\":\"FrameSupportDispatchPays\"}"]
+}
+```
+```json
+{
+  "args": [
+    "{\"_enum\":{\"Other\":\"Null\",\"CannotLookup\":\"Null\",\"BadOrigin\":\"Null\",\"Module\":\"SpRuntimeModuleError\",...}}",
+    "{\"weight\":\"SpWeightsWeightV2Weight\",\"class\":\"FrameSupportDispatchDispatchClass\",\"paysFee\":\"FrameSupportDispatchPays\"}"
+  ]
+}
+```
+
+**This is an intentional difference.** Resolving types to the fully expanded Polkadot.js-style structure introduces significant complexity and fragility for minimal benefit. The simplified type names are the canonical names from the runtime metadata and are sufficient to identify the type. Consumers needing the full type definition can look it up from the runtime metadata directly.
+
+---
+
 ## Fixes
 
 ### Historical data with `?at=`


### PR DESCRIPTION
### Description
This PR updates the migration guide with the section of `Response Differences`. Thi section is added to show the difference in the returned data between rest-api and sidecar in the `args` field and why we accept in the polkadot-rest-api. 
This difference is tracked in the description of https://github.com/paritytech/polkadot-rest-api/issues/167 in point 2 (moved the example difference below).

### Related comments
Comments explaining why we accept this difference:
- https://github.com/paritytech/polkadot-rest-api/issues/167#issuecomment-3910164432
- https://github.com/paritytech/polkadot-rest-api/pull/221#issuecomment-3921595138

### Example Responses
When connected to Kusama and requesting `/v1/pallets/VoterList/errors?at=15205809` endpoint

rest-api response
```json
{
  ...
  "items": [
   {
  ...
          "typeName": "pallet_bags_list::list::ListError",
          "docs": []
        }
  ...
      "args": [
        {
          "name": "",
          "type": "pallet_bags_list::list::ListError",
          "typeName": "ListError"
  ...
```

old sidecar
```json
{
  ...
  "items": [
    {
  ...
          "typeName": "ListError",
          "docs": []
        }
  ...
      "args": [
        "{\"_enum\":[\"Duplicate\",\"NotHeavier\",\"NotInSameBag\",\"NodeNotFound\"]}"
  ...
```
Under the `args` field the data returned are different.

Another example can be found in the `pallets/System/events?at=17500602` endpoint.