### PR TITLE
fix: add build script for docs

### DIFF
--- a/crates/server/build.rs
+++ b/crates/server/build.rs
@@ -1,0 +1,37 @@
+// Copyright (C) 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! Build script that copies `docs/dist` into `OUT_DIR` so that `include_dir!`
+//! works both for local workspace builds and for `cargo publish` verification
+//! (where the package tarball cannot reference paths outside the crate root).
+
+use std::path::Path;
+use std::{env, fs};
+
+fn main() {
+    let out_dir = env::var("OUT_DIR").unwrap();
+    let dest = Path::new(&out_dir).join("docs_dist");
+
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let src = Path::new(&manifest_dir).join("../../docs/dist");
+
+    println!("cargo:rerun-if-changed=../../docs/dist");
+
+    fs::create_dir_all(&dest).unwrap();
+
+    if src.is_dir() {
+        for entry in fs::read_dir(&src).unwrap() {
+            let entry = entry.unwrap();
+            let file_name = entry.file_name();
+            fs::copy(entry.path(), dest.join(&file_name)).unwrap();
+        }
+    } else {
+        // Source not available (e.g. building from a crates.io tarball).
+        // Write a minimal placeholder so include_dir! still compiles.
+        fs::write(
+            dest.join("index.html"),
+            "<html><body>Documentation not available in this build.</body></html>",
+        )
+        .unwrap();
+    }
+}

--- a/crates/server/src/app.rs
+++ b/crates/server/src/app.rs
@@ -13,7 +13,7 @@ use include_dir::{Dir, include_dir};
 use tower_http::{cors::CorsLayer, limit::RequestBodyLimitLayer, trace::TraceLayer};
 use utoipa::OpenApi;
 
-static DOCS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../../docs/dist");
+static DOCS_DIR: Dir = include_dir!("$OUT_DIR/docs_dist");
 
 async fn redirect_docs() -> Redirect {
     Redirect::permanent("/docs/index.html")


### PR DESCRIPTION
When dry-running the publish of polkadot-rest-api, it throws the following error:

```sh
   Compiling polkadot-rest-api v0.1.0-beta.2 (/home/bee344/Documents/parity/rest-migration/polkadot-rest-api/target/package/polkadot-rest-api-0.1.0-beta.2)
error: proc macro panicked
  --> src/app.rs:16:24
   |
16 | static DOCS_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/../../docs/dist");
   |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: message: "/home/bee344/Documents/parity/rest-migration/polkadot-rest-api/target/package/polkadot-rest-api-0.1.0-beta.2/../../docs/dist" is not a directory

error: could not compile `polkadot-rest-api` (lib) due to 1 previous error
error: failed to verify package tarball
```

This fix copies docs/dist/ into $OUT_DIR/docs_dist/ at build time. Falls back to a placeholder if the source directory is missing.