### PR TITLE
fix: remove paraId from coretime/overview

### DIFF
--- a/crates/server/src/handlers/coretime/overview.rs
+++ b/crates/server/src/handlers/coretime/overview.rs
@@ -1277,7 +1277,6 @@ mod tests {
 
         let json = serde_json::to_string(&info).unwrap();
         assert!(json.contains("\"coreId\":5"));
-        assert!(json.contains("\"paraId\":\"2000\""));
         assert!(json.contains("\"workload\""));
         assert!(json.contains("\"type\""));
         assert!(json.contains(&format!("\"condition\":\"{}\"", CORE_TYPE_LEASE)));

--- a/docs/guides/MIGRATION.md
+++ b/docs/guides/MIGRATION.md
@@ -31,6 +31,7 @@ Update all client URLs by prepending `/v1` to existing paths.
 - **Numeric fields**: All u16 and u32 fields are now returned as numbers instead of strings. This is an intentional divergence to provide more accurate JSON types, while maintaining safety for large values (u128 is still returned as a string).
 - **HTTP status codes**: Error responses (e.g., pallet missing at a requested block) now return 400 or 404 instead of 500.
 - **Price fix**: `/v1/coretime/info` — The `currentCorePrice` calculation has been corrected. The previous calculation was faulty. See [PR #175](https://github.com/paritytech/polkadot-rest-api/pull/175).
+- **Removed field**: The field `paraId` was removed from the response of `/v1/coretime/overview`. See [PR #251](https://github.com/paritytech/polkadot-rest-api/pull/251).
 
 ### Query parameter changes
 


### PR DESCRIPTION
As mentioned in the linked issue, having "paraId" in the response is conceptually wrong and misleading on one hand, and duplicates information on the other. Since the introduction of `coretime` a core can be assigned to a `task`, to a `pool` or just `idle`. In the case where a core is assigned to a `task`, the task can be a parachain, in which case the use of `paraId` would be acceptable, but the concept of `task` goes beyond that, so `task != parachain`. At the same time, in the way it was until now, the field could take the value of `Pool`, which does not correspond to a `paraId`, making the field fail to correctly describe the values it represent. Lastly, the information on the current core asssignment is already available via the `workload` field, which provides the appropiate information to determine if it's a `task` or a `pool`, and if the former, which to which task it is assigned, which makes the information redundant.

Closes #238 