### PR TITLE
feat: Implement native HTTP log level tagging for SAS_LOG_LEVEL=http 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3035,6 +3035,7 @@ dependencies = [
  "include_dir",
  "lazy_static",
  "merkleized-metadata",
+ "nu-ansi-term",
  "parity-scale-codec",
  "polkadot-rest-api-config",
  "primitive-types 0.13.1",

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -53,6 +53,7 @@ prometheus = "0.13"
 lazy_static = "1.4"
 regex = "1.10"
 tracing-loki = "0.2"
+nu-ansi-term = "0.50"
 url = "2.5"
 http-body-util = "0.1"
 utoipa = { version = "5", features = ["axum_extras"] }

--- a/crates/server/src/logging/format.rs
+++ b/crates/server/src/logging/format.rs
@@ -1,0 +1,555 @@
+// Copyright (C) 2026 Parity Technologies (UK) Ltd.
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+use std::fmt;
+use tracing::{Event, Level, Subscriber};
+use tracing_subscriber::{
+    fmt::{
+        FmtContext, FormatFields, FormattedFields,
+        format::{self, FormatEvent, Writer},
+        time::{FormatTime, SystemTime},
+    },
+    registry::LookupSpan,
+};
+
+use nu_ansi_term::{Color, Style};
+
+/// Returns true when the event should display "HTTP" instead of its actual level.
+/// This applies to events with target "http" at DEBUG level (2xx/3xx responses).
+fn is_http_display_event(event: &Event<'_>) -> bool {
+    let meta = event.metadata();
+    meta.target() == "http" && *meta.level() == Level::DEBUG
+}
+
+/// Human-readable formatter that displays "HTTP" instead of "DEBUG" for HTTP events.
+///
+/// For HTTP events this renders the line directly (instead of delegating to the
+/// standard `Format<Full>` formatter and patching the output), so the custom
+/// level label is produced without fragile string replacement.
+pub struct HttpAwareFormat {
+    inner: format::Format<format::Full>,
+    timer: SystemTime,
+    use_ansi: bool,
+}
+
+impl HttpAwareFormat {
+    pub fn new(strip_ansi: bool) -> Self {
+        let inner = format::format()
+            .with_target(true)
+            .with_file(true)
+            .with_line_number(true)
+            .with_ansi(!strip_ansi);
+
+        Self {
+            inner,
+            timer: SystemTime,
+            use_ansi: !strip_ansi,
+        }
+    }
+
+    /// Render an HTTP event directly, writing " HTTP" as the level label.
+    ///
+    /// This intentionally reimplements the rendering sequence from
+    /// `Format<Full>::format_event` so that we can
+    /// substitute the level string without string replacement.
+    fn format_http_event<S, N>(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result
+    where
+        S: Subscriber + for<'a> LookupSpan<'a>,
+        N: for<'a> FormatFields<'a> + 'static,
+    {
+        let meta = event.metadata();
+
+        let dimmed = if self.use_ansi {
+            Style::new().dimmed()
+        } else {
+            Style::new()
+        };
+        let bold = if self.use_ansi {
+            Style::new().bold()
+        } else {
+            Style::new()
+        };
+
+        if self.use_ansi {
+            write!(writer, "{}", dimmed.prefix())?;
+            if self.timer.format_time(&mut writer).is_err() {
+                writer.write_str("<unknown time>")?;
+            }
+            write!(writer, "{} ", dimmed.suffix())?;
+        } else {
+            if self.timer.format_time(&mut writer).is_err() {
+                writer.write_str("<unknown time>")?;
+            }
+            writer.write_char(' ')?;
+        }
+
+        if self.use_ansi {
+            write!(writer, "{} ", Color::Cyan.paint(" HTTP"))?;
+        } else {
+            writer.write_str(" HTTP ")?;
+        }
+
+        if let Some(scope) = ctx.event_scope() {
+            let mut seen = false;
+            for span in scope.from_root() {
+                write!(writer, "{}", bold.paint(span.metadata().name()))?;
+                seen = true;
+
+                let ext = span.extensions();
+                if let Some(fields) = &ext.get::<FormattedFields<N>>()
+                    && !fields.is_empty()
+                {
+                    write!(writer, "{}{}{}", bold.paint("{"), fields, bold.paint("}"))?;
+                }
+                write!(writer, "{}", dimmed.paint(":"))?;
+            }
+
+            if seen {
+                writer.write_char(' ')?;
+            }
+        }
+
+        write!(
+            writer,
+            "{}{} ",
+            dimmed.paint(meta.target()),
+            dimmed.paint(":")
+        )?;
+
+        if let Some(filename) = meta.file() {
+            write!(writer, "{}{}", dimmed.paint(filename), dimmed.paint(":"),)?;
+        }
+        if let Some(line_number) = meta.line() {
+            write!(
+                writer,
+                "{}{}:{} ",
+                dimmed.prefix(),
+                line_number,
+                dimmed.suffix(),
+            )?;
+        }
+
+        ctx.format_fields(writer.by_ref(), event)?;
+
+        writeln!(writer)
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for HttpAwareFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        if is_http_display_event(event) {
+            self.format_http_event(ctx, writer, event)
+        } else {
+            self.inner.format_event(ctx, writer, event)
+        }
+    }
+}
+
+/// JSON formatter that replaces `"level":"DEBUG"` with `"level":"HTTP"` for HTTP events.
+pub struct HttpAwareJsonFormat {
+    inner: format::Format<format::Json>,
+}
+
+impl Default for HttpAwareJsonFormat {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl HttpAwareJsonFormat {
+    pub fn new() -> Self {
+        Self {
+            inner: format::format().json(),
+        }
+    }
+}
+
+impl<S, N> FormatEvent<S, N> for HttpAwareJsonFormat
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+    N: for<'a> FormatFields<'a> + 'static,
+{
+    fn format_event(
+        &self,
+        ctx: &FmtContext<'_, S, N>,
+        mut writer: Writer<'_>,
+        event: &Event<'_>,
+    ) -> fmt::Result {
+        if !is_http_display_event(event) {
+            return self.inner.format_event(ctx, writer, event);
+        }
+
+        let mut buf = String::new();
+        let buf_writer = Writer::new(&mut buf);
+        self.inner.format_event(ctx, buf_writer, event)?;
+
+        let trimmed = buf.trim_end();
+        match serde_json::from_str::<serde_json::Value>(trimmed) {
+            Ok(mut json) => {
+                if let Some(obj) = json.as_object_mut() {
+                    obj.insert(
+                        "level".to_string(),
+                        serde_json::Value::String("http".to_string()),
+                    );
+                }
+                let patched = serde_json::to_string(&json).map_err(|_| fmt::Error)?;
+                writer.write_str(&patched)?;
+                writeln!(writer)
+            }
+            Err(_) => {
+                // Fallback: write original buffer unchanged
+                writer.write_str(&buf)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+    use tracing::{debug, error, warn};
+    use tracing_subscriber::{EnvFilter, fmt, layer::SubscriberExt, util::SubscriberInitExt};
+
+    use super::*;
+
+    #[derive(Clone)]
+    struct TestWriter {
+        buf: Arc<Mutex<Vec<u8>>>,
+    }
+
+    impl TestWriter {
+        fn new() -> Self {
+            Self {
+                buf: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
+
+        fn output(&self) -> String {
+            let buf = self.buf.lock().unwrap();
+            String::from_utf8_lossy(&buf).to_string()
+        }
+    }
+
+    impl std::io::Write for TestWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.buf.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for TestWriter {
+        type Writer = TestWriter;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    #[test]
+    fn test_http_event_shows_http_level() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("debug").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareFormat::new(true))
+                    .with_ansi(false)
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        debug!(target: "http", "GET /test 200 10ms");
+
+        let output = writer.output();
+        assert!(
+            output.contains("HTTP"),
+            "Expected 'HTTP' in output, got: {}",
+            output
+        );
+        assert!(
+            !output.contains("DEBUG"),
+            "Did not expect 'DEBUG' in output, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_non_http_debug_shows_debug() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("debug").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareFormat::new(true))
+                    .with_ansi(false)
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        debug!(target: "something_else", "some debug message");
+
+        let output = writer.output();
+        assert!(
+            output.contains("DEBUG"),
+            "Expected 'DEBUG' in output, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_http_warn_stays_warn() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("warn").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareFormat::new(true))
+                    .with_ansi(false)
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        warn!(target: "http", "GET /test 404 10ms");
+
+        let output = writer.output();
+        assert!(
+            output.contains("WARN"),
+            "Expected 'WARN' in output, got: {}",
+            output
+        );
+        assert!(
+            !output.contains("HTTP"),
+            "Did not expect 'HTTP' in output, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_json_http_event_level() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("debug").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareJsonFormat::new())
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        debug!(target: "http", "GET /test 200 10ms");
+
+        let output = writer.output();
+        let json: serde_json::Value =
+            serde_json::from_str(output.trim()).expect("valid JSON output");
+        assert_eq!(
+            json["level"], "http",
+            "Expected level 'http', got: {}",
+            json["level"]
+        );
+    }
+
+    #[test]
+    fn test_json_non_http_unchanged() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("debug").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareJsonFormat::new())
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        debug!(target: "other", "some debug message");
+
+        let output = writer.output();
+        let json: serde_json::Value =
+            serde_json::from_str(output.trim()).expect("valid JSON output");
+        assert_eq!(
+            json["level"], "DEBUG",
+            "Expected level 'DEBUG', got: {}",
+            json["level"]
+        );
+    }
+
+    #[test]
+    fn test_http_event_does_not_replace_debug_in_message() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("debug").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareFormat::new(true))
+                    .with_ansi(false)
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        debug!(target: "http", "GET /api/DEBUG/test 200 10ms");
+
+        let output = writer.output();
+        assert!(
+            output.contains("HTTP"),
+            "Expected 'HTTP' level in output, got: {}",
+            output
+        );
+        assert!(
+            output.contains("GET /api/DEBUG/test"),
+            "Expected 'DEBUG' preserved in message body, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_http_event_with_ansi() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("debug").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareFormat::new(false))
+                    .with_ansi(true)
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        debug!(target: "http", "GET /test 200 10ms");
+
+        let output = writer.output();
+        assert!(
+            output.contains("HTTP"),
+            "Expected 'HTTP' in ANSI output, got: {:?}",
+            output
+        );
+        assert!(
+            !output.contains("DEBUG"),
+            "Did not expect 'DEBUG' in ANSI output, got: {:?}",
+            output
+        );
+        assert!(
+            output.contains("GET /test 200 10ms"),
+            "Expected message in output, got: {:?}",
+            output
+        );
+        assert!(
+            output.contains("\x1b["),
+            "Expected ANSI escape codes in output, got: {:?}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_http_error_stays_error() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("error").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareFormat::new(true))
+                    .with_ansi(false)
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        error!(target: "http", "GET /test 500 10ms");
+
+        let output = writer.output();
+        assert!(
+            output.contains("ERROR"),
+            "Expected 'ERROR' in output, got: {}",
+            output
+        );
+        assert!(
+            !output.contains("HTTP"),
+            "Did not expect 'HTTP' in output for error-level event, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_http_filter_passes_http_debug_but_not_other_debug() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("info,http=debug").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareFormat::new(true))
+                    .with_ansi(false)
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        debug!(target: "http", "GET /test 200 10ms");
+        debug!(target: "some_module", "internal debug info");
+
+        let output = writer.output();
+        assert!(
+            output.contains("HTTP"),
+            "Expected HTTP debug event to pass filter, got: {}",
+            output
+        );
+        assert!(
+            !output.contains("internal debug info"),
+            "Non-HTTP debug event should be filtered out, got: {}",
+            output
+        );
+    }
+
+    #[test]
+    fn test_json_http_event_preserves_debug_in_message() {
+        let writer = TestWriter::new();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::try_new("debug").unwrap())
+            .with(
+                fmt::layer()
+                    .event_format(HttpAwareJsonFormat::new())
+                    .with_writer(writer.clone()),
+            );
+
+        let _guard = subscriber.set_default();
+
+        debug!(target: "http", "GET /api/DEBUG/test 200 10ms");
+
+        let output = writer.output();
+        let json: serde_json::Value =
+            serde_json::from_str(output.trim()).expect("valid JSON output");
+        assert_eq!(
+            json["level"], "http",
+            "Expected level 'http', got: {}",
+            json["level"]
+        );
+        let fields = json["fields"]["message"].as_str().unwrap_or("");
+        assert!(
+            fields.contains("DEBUG"),
+            "Expected 'DEBUG' preserved in message field, got: {}",
+            fields
+        );
+    }
+}

--- a/crates/server/src/logging/http_logger.rs
+++ b/crates/server/src/logging/http_logger.rs
@@ -6,7 +6,7 @@ use std::time::Instant;
 
 /// HTTP logger middleware that logs request method, path, status code, and duration.
 ///
-/// - Logs with INFO level (target: http) for 2xx/3xx responses
+/// - Logs with DEBUG level (target: http, displayed as "HTTP") for 1xx/2xx/3xx responses
 /// - Logs with WARN level for 4xx responses
 /// - Logs with ERROR level for 5xx responses
 ///
@@ -38,7 +38,7 @@ pub async fn http_logger_middleware(req: Request, next: Next) -> Response {
 
     // Emit tracing event based on status code
     match status_code {
-        200..=399 => {
+        ..=399 => {
             tracing::debug!(
                 target: "http",
                 method = %method,

--- a/crates/server/src/logging/logger.rs
+++ b/crates/server/src/logging/logger.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+use super::format::{HttpAwareFormat, HttpAwareJsonFormat};
 use rolling_file::*;
 use std::path::PathBuf;
 use thiserror::Error;
@@ -96,13 +97,21 @@ pub fn init_with_config(config: LoggingConfig) -> Result<(), LoggingError> {
     let write_max_file_size = config.write_max_file_size;
     let write_max_files = config.write_max_files;
     let loki_url = config.loki_url;
-    // Create filter from level
-    // Resolve "http" log level to "debug" for the filter
+    // Create filter from level.
+    //
+    // The "http" level mirrors substrate-api-sidecar's hierarchy where
+    // "http" sits between "info" and "debug":
+    //   error > warn > info > http > debug > trace
+    //
+    // "info,http=debug" means: show info/warn/error from all targets,
+    // PLUS debug-level events from the "http" target (which the
+    // HttpAwareFormat/HttpAwareJsonFormat formatters display as "HTTP").
+    // Non-HTTP debug events are filtered out — matching sidecar's
+    // behavior where SAS_LOG_LEVEL=http shows request logs alongside
+    // info-level application logs, but not verbose debug output.
     let filter_level = if level == "http" {
-        // Translate to target filter
         "info,http=debug"
     } else {
-        // Standard level
         level
     };
 
@@ -159,8 +168,10 @@ pub fn init_with_config(config: LoggingConfig) -> Result<(), LoggingError> {
 
         if json_format {
             // JSON format for both console and file
-            let console_layer = fmt::layer().json();
-            let file_layer = fmt::layer().json().with_writer(non_blocking);
+            let console_layer = fmt::layer().event_format(HttpAwareJsonFormat::new());
+            let file_layer = fmt::layer()
+                .event_format(HttpAwareJsonFormat::new())
+                .with_writer(non_blocking);
 
             if let Some(loki) = loki_layer {
                 registry
@@ -179,18 +190,12 @@ pub fn init_with_config(config: LoggingConfig) -> Result<(), LoggingError> {
         } else {
             // Human-readable format for both console and file
             let console_layer = fmt::layer()
-                .with_target(true)
-                .with_thread_ids(false)
-                .with_file(true)
-                .with_line_number(true)
+                .event_format(HttpAwareFormat::new(strip_ansi))
                 .with_ansi(!strip_ansi);
 
             let file_layer = fmt::layer()
-                .with_target(true)
-                .with_thread_ids(false)
-                .with_file(true)
-                .with_line_number(true)
-                .with_ansi(false) // Never use ANSI in files
+                .event_format(HttpAwareFormat::new(true))
+                .with_ansi(false)
                 .with_writer(non_blocking);
 
             if let Some(loki) = loki_layer {
@@ -211,7 +216,7 @@ pub fn init_with_config(config: LoggingConfig) -> Result<(), LoggingError> {
     } else {
         // Console output only
         if json_format {
-            let fmt_layer = fmt::layer().json();
+            let fmt_layer = fmt::layer().event_format(HttpAwareJsonFormat::new());
             if let Some(loki) = loki_layer {
                 registry.with(filter).with(fmt_layer).with(loki).init();
             } else {
@@ -219,10 +224,7 @@ pub fn init_with_config(config: LoggingConfig) -> Result<(), LoggingError> {
             }
         } else {
             let fmt_layer = fmt::layer()
-                .with_target(true)
-                .with_thread_ids(false)
-                .with_file(true)
-                .with_line_number(true)
+                .event_format(HttpAwareFormat::new(strip_ansi))
                 .with_ansi(!strip_ansi);
 
             if let Some(loki) = loki_layer {

--- a/crates/server/src/logging/mod.rs
+++ b/crates/server/src/logging/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2026 Parity Technologies (UK) Ltd.
 // SPDX-License-Identifier: GPL-3.0-or-later
 
+pub mod format;
 pub mod http_logger;
 pub mod logger;
 pub use http_logger::http_logger_middleware;


### PR DESCRIPTION
Implement native `HTTP` log level tagging for `SAS_LOG_LEVEL=http`. Previously, successful HTTP responses were logged as `DEBUG`, making them indistinguishable from general debug output. This introduces custom `tracing` formatters that display a native `HTTP` level label, matching substrate-api-sidecar's `http > debug` hierarchy.

## Changes

- **Custom formatters** (`format.rs`): Introduce `HttpAwareFormat` (human-readable) and `HttpAwareJsonFormat` (JSON) that intercept `target: "http"` events at `DEBUG` level and render them with an `HTTP` tag — reimplementing the rendering path to avoid fragile string replacement
- **Logger integration** (`logger.rs`): Wire the new formatters into all output paths (console, file, JSON)
- **HTTP logger tweak** (`http_logger.rs`): Expand the success range to `..=399` (covering 1xx responses)
- **Tests**: 10 unit tests covering HTTP/non-HTTP events, ANSI output, JSON level patching, message preservation, and filter behavior

closes #76 
