### PR TITLE
chore: replace `Err(_)` with useful debug logging

### DIFF
--- a/crates/server/src/handlers/accounts/utils/address.rs
+++ b/crates/server/src/handlers/accounts/utils/address.rs
@@ -19,7 +19,8 @@ pub fn get_network_name(prefix: u16) -> Option<String> {
     let format = Ss58AddressFormat::custom(prefix);
     match Ss58AddressFormatRegistry::try_from(format) {
         Ok(registry) => Some(registry.to_string()),
-        Err(_) => {
+        Err(e) => {
+            tracing::debug!("Unknown SS58 prefix {prefix}: {e:?}");
             // For unknown prefixes, return a generic name
             // This is more flexible for custom networks
             Some(format!("unknown-{}", prefix))

--- a/crates/server/src/handlers/blocks/common.rs
+++ b/crates/server/src/handlers/blocks/common.rs
@@ -165,7 +165,7 @@ pub async fn get_validators_at_block(
     use crate::handlers::runtime_queries::session;
 
     session::get_validators(client_at_block).await.map_err(|e| {
-        tracing::debug!("Failed to get validators: {}", e);
+        tracing::debug!("Failed to get validators: {:?}", e);
         match e {
             session::SessionStorageError::NoValidatorsFound => GetBlockError::StorageDecodeFailed(
                 parity_scale_codec::Error::from("no validators found in storage"),
@@ -211,7 +211,11 @@ pub async fn extract_author_with_prefix(
     let validators = match get_validators_at_block(client_at_block).await {
         Ok(v) => v,
         Err(e) => {
-            tracing::debug!("Failed to get validators for block {}: {}", block_number, e);
+            tracing::debug!(
+                "Failed to get validators for block {:?}: {:?}",
+                block_number,
+                e
+            );
             return None;
         }
     };
@@ -540,7 +544,12 @@ pub async fn build_block_response_generic(
                             match canonical_result {
                                 Ok(Some(canonical_hash)) => Some(canonical_hash == block_hash),
                                 Ok(None) => Some(false),
-                                Err(_) => Some(false),
+                                Err(e) => {
+                                    tracing::debug!(
+                                        "Failed to fetch canonical hash for block: {e:?}"
+                                    );
+                                    Some(false)
+                                }
                             }
                         } else {
                             Some(true)
@@ -552,7 +561,10 @@ pub async fn build_block_response_generic(
                     Some(false)
                 }
             }
-            Err(_) => None,
+            Err(e) => {
+                tracing::debug!("Failed to get finalized block number: {e:?}");
+                None
+            }
         }
     } else {
         None

--- a/crates/server/src/handlers/blocks/decode/args.rs
+++ b/crates/server/src/handlers/blocks/decode/args.rs
@@ -481,7 +481,8 @@ impl<'r, const CAMEL_CASE: bool> ScaleVisitor<'r, CAMEL_CASE> {
                 let field = field?;
                 match field.decode_with_visitor(ByteCollector) {
                     Ok(field_bytes) => bytes.extend(field_bytes),
-                    Err(_) => {
+                    Err(e) => {
+                        tracing::debug!("Failed to decode composite field bytes: {e:?}");
                         bytes.clear();
                         break;
                     }

--- a/crates/server/src/handlers/blocks/decode/events.rs
+++ b/crates/server/src/handlers/blocks/decode/events.rs
@@ -439,7 +439,12 @@ impl<'r> Visitor for FieldWithTypeExtractor<'r> {
             {
                 match field_result {
                     Ok(inner_value) => return Ok((type_name, inner_value)),
-                    Err(_) => return Ok((type_name, JsonValue::Null)),
+                    Err(e) => {
+                        tracing::debug!(
+                            "Failed to decode Option::Some inner value (FieldWithTypeExtractor): {e:?}"
+                        );
+                        return Ok((type_name, JsonValue::Null));
+                    }
                 }
             }
             return Ok((type_name, JsonValue::Null));
@@ -669,7 +674,12 @@ impl<'r> Visitor for ValueExtractor<'r> {
             {
                 match field_result {
                     Ok(inner_value) => return Ok(inner_value),
-                    Err(_) => return Ok(JsonValue::Null),
+                    Err(e) => {
+                        tracing::debug!(
+                            "Failed to decode Option::Some inner value(ValueExtractor): {e:?}"
+                        );
+                        return Ok(JsonValue::Null);
+                    }
                 }
             }
             return Ok(JsonValue::Null);

--- a/crates/server/src/handlers/blocks/decode/xcm.rs
+++ b/crates/server/src/handlers/blocks/decode/xcm.rs
@@ -211,7 +211,10 @@ fn decode_xcm_message(hex_str: &str) -> Value {
             // Wrap in array to match sidecar format: "data": [{ "v4": [...] }]
             Value::Array(vec![scale_value_to_json(value, &registry)])
         }
-        Err(_) => Value::String(hex_str.to_string()),
+        Err(e) => {
+            tracing::debug!("Failed to decode XCM message: {e:?}");
+            Value::String(hex_str.to_string())
+        }
     }
 }
 

--- a/crates/server/src/handlers/blocks/processing/fees.rs
+++ b/crates/server/src/handlers/blocks/processing/fees.rs
@@ -118,7 +118,10 @@ pub async fn extract_fee_info_for_extrinsic(
 
     let extrinsic_bytes = match hex::decode(extrinsic_hex.trim_start_matches("0x")) {
         Ok(bytes) => bytes,
-        Err(_) => return serde_json::Map::new(),
+        Err(e) => {
+            tracing::debug!("Failed to hex-decode extrinsic bytes: {e:?}");
+            return serde_json::Map::new();
+        }
     };
 
     // Check if we need fee details for Priority 2

--- a/crates/server/src/handlers/node/common.rs
+++ b/crates/server/src/handlers/node/common.rs
@@ -119,7 +119,10 @@ pub async fn fetch_node_network(rpc_client: &RpcClient) -> Result<NodeNetworkRes
         .await
     {
         Ok(peers) => transform_peers_info(peers),
-        Err(_) => Value::String("Cannot query system_peers from node.".to_string()),
+        Err(e) => {
+            tracing::debug!("Failed to query system_peers: {e:?}");
+            Value::String("Cannot query system_peers from node.".to_string())
+        }
     };
 
     Ok(NodeNetworkResponse {
@@ -533,7 +536,10 @@ async fn calculate_priority(
                         "0".to_string()
                     }
                 }
-                Err(_) => "0".to_string(),
+                Err(e) => {
+                    tracing::debug!("Failed to query fee details for operational priority: {e:?}");
+                    "0".to_string()
+                }
             }
         }
         _ => "0".to_string(),

--- a/crates/server/src/handlers/pallets/asset_conversion.rs
+++ b/crates/server/src/handlers/pallets/asset_conversion.rs
@@ -347,17 +347,26 @@ async fn fetch_liquidity_pools(
                                     )
                                 }
                             }
-                            Err(_) => serde_json::Value::Null,
+                            Err(e) => {
+                                tracing::debug!("Failed to decode pool storage key: {e:?}");
+                                serde_json::Value::Null
+                            }
                         }
                     }
-                    Err(_) => serde_json::Value::Null,
+                    Err(e) => {
+                        tracing::debug!("Failed to decode pool key: {e:?}");
+                        serde_json::Value::Null
+                    }
                 };
 
                 // Convert value (pool info) to JSON
                 // value.decode() returns Result<scale_value::Value, Error>
                 let lp_token = match value.decode() {
                     Ok(val) => scale_value_to_json(&val),
-                    Err(_) => serde_json::Value::Null,
+                    Err(e) => {
+                        tracing::debug!("Failed to decode pool value: {e:?}");
+                        serde_json::Value::Null
+                    }
                 };
 
                 pools.push(LiquidityPoolInfo {

--- a/crates/server/src/handlers/pallets/staking_validators.rs
+++ b/crates/server/src/handlers/pallets/staking_validators.rs
@@ -297,7 +297,10 @@ async fn fetch_active_validators_set(
 ) -> Result<HashSet<String>, PalletError> {
     // Try ErasStakersOverview first
     match fetch_active_era_index(client_at_block).await {
-        Err(_) => Err(PalletError::CurrentOrActiveEraNotFound),
+        Err(e) => {
+            tracing::debug!("Failed to fetch active era index: {e:?}");
+            Err(PalletError::CurrentOrActiveEraNotFound)
+        }
         Ok(active_era) => {
             if let Ok(set) =
                 fetch_era_stakers_overview_keys(client_at_block, active_era, ss58_prefix).await

--- a/crates/server/src/handlers/paras/paras_inclusion.rs
+++ b/crates/server/src/handlers/paras/paras_inclusion.rs
@@ -256,7 +256,10 @@ async fn extract_relay_parent_number(
     for ext_result in extrinsics.iter() {
         let ext = match ext_result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to decode extrinsic: {e:?}");
+                continue;
+            }
         };
 
         if ext.pallet_name() == "ParachainSystem" && ext.call_name() == "set_validation_data" {
@@ -339,7 +342,10 @@ async fn check_block_for_inclusion(
     for event_result in events.iter() {
         let event = match event_result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to decode event: {e:?}");
+                continue;
+            }
         };
 
         // Use the clean pallet_name() and event_name() API
@@ -349,7 +355,10 @@ async fn check_block_for_inclusion(
 
         let event_data: CandidateIncludedEvent = match event.decode_fields_unchecked_as() {
             Ok(v) => v,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to decode CandidateIncluded event fields: {e:?}");
+                continue;
+            }
         };
 
         if let Some(inclusion_block_num) =

--- a/crates/server/src/handlers/rc/accounts/get_staking_info.rs
+++ b/crates/server/src/handlers/rc/accounts/get_staking_info.rs
@@ -74,7 +74,12 @@ pub async fn get_staking_info(
     // For RC endpoints, use relay chain spec_name if available
     let rc_spec_name = match state.get_relay_chain_info().await {
         Ok(info) => info.spec_name.clone(),
-        Err(_) => state.chain_info.spec_name.clone(),
+        Err(e) => {
+            tracing::debug!(
+                "Failed to get relay chain info, falling back to local spec name: {e:?}"
+            );
+            state.chain_info.spec_name.clone()
+        }
     };
 
     let raw_info = query_staking_info(

--- a/crates/server/src/handlers/rc/accounts/get_staking_payouts.rs
+++ b/crates/server/src/handlers/rc/accounts/get_staking_payouts.rs
@@ -87,7 +87,12 @@ pub async fn get_staking_payouts(
     // For RC endpoints, use relay chain spec_name if available
     let rc_spec_name = match state.get_relay_chain_info().await {
         Ok(info) => info.spec_name.clone(),
-        Err(_) => state.chain_info.spec_name.clone(),
+        Err(e) => {
+            tracing::debug!(
+                "Failed to get relay chain info, falling back to local spec name: {e:?}"
+            );
+            state.chain_info.spec_name.clone()
+        }
     };
 
     // RC endpoints query the relay chain directly, no migration splitting needed

--- a/crates/server/src/handlers/runtime_queries/assets.rs
+++ b/crates/server/src/handlers/runtime_queries/assets.rs
@@ -155,7 +155,10 @@ pub async fn get_asset_info(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch asset info for asset {asset_id}: {e:?}");
+            return Ok(None);
+        }
     };
 
     let details: AssetDetails = value
@@ -193,7 +196,10 @@ pub async fn get_asset_metadata(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch asset metadata for asset {asset_id}: {e:?}");
+            return Ok(None);
+        }
     };
 
     let metadata: AssetMetadata = value
@@ -226,7 +232,10 @@ pub async fn get_asset_balance(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch asset balance for asset {asset_id}: {e:?}");
+            return Ok(None);
+        }
     };
 
     let raw_bytes = value.into_bytes();
@@ -288,7 +297,10 @@ pub async fn get_asset_balances(
                     ));
                 }
             }
-            Err(_) if show_empty => {
+            Err(e) if show_empty => {
+                tracing::debug!(
+                    "Failed to fetch asset balance for asset (show_empty) {asset_id}: {e:?}"
+                );
                 balances.push((
                     asset_id,
                     DecodedAssetBalance {
@@ -298,7 +310,9 @@ pub async fn get_asset_balances(
                     },
                 ));
             }
-            Err(_) => {}
+            Err(e) => {
+                tracing::debug!("Failed to fetch asset balance for asset {asset_id}: {e:?}");
+            }
         }
     }
 
@@ -324,7 +338,10 @@ pub async fn get_asset_approval(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch asset approval for asset {asset_id}: {e:?}");
+            return Ok(None);
+        }
     };
 
     let raw_bytes = value.into_bytes();

--- a/crates/server/src/handlers/runtime_queries/balances.rs
+++ b/crates/server/src/handlers/runtime_queries/balances.rs
@@ -189,7 +189,10 @@ pub async fn get_balance_locks(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Vec::new(),
+        Err(e) => {
+            tracing::debug!("Failed to fetch balance locks: {e:?}");
+            return Vec::new();
+        }
     };
 
     let raw_bytes = value.into_bytes();
@@ -229,7 +232,10 @@ pub async fn get_vesting_schedules(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Vec::new(),
+        Err(e) => {
+            tracing::debug!("Failed to fetch vesting schedules: {e:?}");
+            return Vec::new();
+        }
     };
 
     let raw_bytes = value.into_bytes();

--- a/crates/server/src/handlers/runtime_queries/broker.rs
+++ b/crates/server/src/handlers/runtime_queries/broker.rs
@@ -132,7 +132,8 @@ pub async fn get_leases(
         Err(subxt::error::StorageError::StorageEntryNotFound { .. }) => {
             return Ok(vec![]);
         }
-        Err(_) => {
+        Err(e) => {
+            tracing::debug!("Failed to fetch Broker::Leases: {e:?}");
             return Err(BrokerStorageError::StorageFetchFailed {
                 pallet: "Broker",
                 entry: "Leases",
@@ -164,7 +165,8 @@ pub async fn get_reservations(
         Err(subxt::error::StorageError::StorageEntryNotFound { .. }) => {
             return Ok(vec![]);
         }
-        Err(_) => {
+        Err(e) => {
+            tracing::debug!("Failed to fetch Broker::Reservations: {e:?}");
             return Err(BrokerStorageError::StorageFetchFailed {
                 pallet: "Broker",
                 entry: "Reservations",
@@ -212,9 +214,15 @@ pub async fn iter_workloads(
         let core: u32 = match entry.key() {
             Ok(storage_key) => match storage_key.decode() {
                 Ok(key) => key.0 as u32,
-                Err(_) => continue,
+                Err(e) => {
+                    tracing::debug!("Failed to decode workload key: {e:?}");
+                    continue;
+                }
             },
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to parse workload storage key: {e:?}");
+                continue;
+            }
         };
 
         // Decode workload value into typed struct and extract task
@@ -736,7 +744,8 @@ pub async fn iter_workplans(
         // Decode workplan value using DecodeAsType
         let items = match entry.value().decode_as::<Vec<ScheduleItem>>() {
             Ok(v) => v,
-            Err(_) => {
+            Err(err) => {
+                tracing::debug!("Failed to decode workplan schedule items: {err:?}");
                 // OptionQuery might wrap the value
                 match entry.value().decode_as::<Option<Vec<ScheduleItem>>>() {
                     Ok(Some(v)) => v,

--- a/crates/server/src/handlers/runtime_queries/coretime.rs
+++ b/crates/server/src/handlers/runtime_queries/coretime.rs
@@ -64,10 +64,13 @@ pub async fn get_broker_id(
     let addr = subxt::dynamic::constant::<u32>("Coretime", "BrokerId");
     match client_at_block.constants().entry(addr) {
         Ok(value) => Ok(Some(value)),
-        Err(_) => Err(CoretimeStorageError::ConstantFetchFailed {
-            pallet: "Coretime",
-            constant: "BrokerId",
-        }),
+        Err(e) => {
+            tracing::debug!("Failed to fetch Coretime::BrokerId constant: {e:?}");
+            Err(CoretimeStorageError::ConstantFetchFailed {
+                pallet: "Coretime",
+                constant: "BrokerId",
+            })
+        }
     }
 }
 
@@ -103,6 +106,9 @@ pub async fn get_max_historical_revenue(
         subxt::dynamic::constant::<u32>("OnDemandAssignmentProvider", "MaxHistoricalRevenue");
     match client_at_block.constants().entry(legacy_addr) {
         Ok(value) => Ok(Some(value)),
-        Err(_) => Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch MaxHistoricalRevenue constant: {e:?}");
+            Ok(None)
+        }
     }
 }

--- a/crates/server/src/handlers/runtime_queries/foreign_assets.rs
+++ b/crates/server/src/handlers/runtime_queries/foreign_assets.rs
@@ -104,7 +104,10 @@ pub async fn iter_foreign_asset_locations(
     while let Some(result) = stream.next().await {
         let entry = match result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to iterate foreign asset location entry: {e:?}");
+                continue;
+            }
         };
 
         // Extract Location from storage key
@@ -142,7 +145,10 @@ pub async fn iter_foreign_assets(
     while let Some(result) = stream.next().await {
         let entry = match result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to iterate foreign asset entry: {e:?}");
+                continue;
+            }
         };
 
         // Extract Location from storage key
@@ -206,7 +212,10 @@ pub async fn iter_foreign_asset_metadata(
     while let Some(result) = stream.next().await {
         let entry = match result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to iterate foreign asset metadata entry: {e:?}");
+                continue;
+            }
         };
 
         // Extract Location from storage key
@@ -388,7 +397,10 @@ pub async fn get_foreign_asset_account(
                         is_sufficient,
                     })
                 }
-                Err(_) => None,
+                Err(e) => {
+                    tracing::debug!("Failed to decode foreign asset account: {e:?}");
+                    None
+                }
             }
         }
         Err(_) => None, // No entry for this (location, account) pair
@@ -413,7 +425,10 @@ pub async fn get_foreign_asset_account_raw(
     match result {
         Ok(value) => match value.decode_as::<scale_value::Value<()>>() {
             Ok(decoded) => Ok(Some(decoded)),
-            Err(_) => Err("Failed to decode ForeignAssets::Account as scale_value"),
+            Err(e) => {
+                tracing::debug!("Failed to decode ForeignAssets::Account as scale_value: {e:?}");
+                Err("Failed to decode ForeignAssets::Account as scale_value")
+            }
         },
         Err(_) => Ok(None), // No entry for this (location, account) pair
     }

--- a/crates/server/src/handlers/runtime_queries/nomination_pools.rs
+++ b/crates/server/src/handlers/runtime_queries/nomination_pools.rs
@@ -143,7 +143,10 @@ pub async fn get_bonded_pool(
     let addr = subxt::dynamic::storage::<_, scale_value::Value>("NominationPools", "BondedPools");
     let raw_bytes = match client_at_block.storage().fetch(addr, (pool_id,)).await {
         Ok(value) => value.into_bytes(),
-        Err(_) => return None,
+        Err(e) => {
+            tracing::debug!("Failed to fetch BondedPools storage: {e:?}");
+            return None;
+        }
     };
 
     // Try modern V2 format first (with commission)
@@ -176,7 +179,10 @@ pub async fn get_reward_pool(
     let addr = subxt::dynamic::storage::<_, scale_value::Value>("NominationPools", "RewardPools");
     let raw_bytes = match client_at_block.storage().fetch(addr, (pool_id,)).await {
         Ok(value) => value.into_bytes(),
-        Err(_) => return None,
+        Err(e) => {
+            tracing::debug!("Failed to fetch RewardPools storage: {e:?}");
+            return None;
+        }
     };
 
     // Try modern V2 format first (with commission tracking)

--- a/crates/server/src/handlers/runtime_queries/pool_assets.rs
+++ b/crates/server/src/handlers/runtime_queries/pool_assets.rs
@@ -159,7 +159,10 @@ pub async fn get_pool_asset_info(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch pool asset info for asset {asset_id}: {e:?}");
+            return Ok(None);
+        }
     };
 
     let details: AssetDetails = value
@@ -197,7 +200,10 @@ pub async fn get_pool_asset_metadata(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch pool asset metadata for asset {asset_id}: {e:?}");
+            return Ok(None);
+        }
     };
 
     let metadata: AssetMetadata = value
@@ -230,7 +236,10 @@ pub async fn get_pool_asset_balance(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch pool asset balance for asset {asset_id}: {e:?}");
+            return Ok(None);
+        }
     };
 
     let raw_bytes = value.into_bytes();
@@ -291,7 +300,10 @@ pub async fn get_pool_asset_balances(
                     ));
                 }
             }
-            Err(_) if show_empty => {
+            Err(e) if show_empty => {
+                tracing::debug!(
+                    "Failed to fetch pool asset balance for asset (show_empty) {asset_id}: {e:?}"
+                );
                 balances.push((
                     asset_id,
                     DecodedPoolAssetBalance {
@@ -301,7 +313,9 @@ pub async fn get_pool_asset_balances(
                     },
                 ));
             }
-            Err(_) => {}
+            Err(e) => {
+                tracing::debug!("Failed to fetch pool asset balance for asset {asset_id}: {e:?}");
+            }
         }
     }
 
@@ -327,7 +341,10 @@ pub async fn get_pool_asset_approval(
         .await
     {
         Ok(v) => v,
-        Err(_) => return Ok(None),
+        Err(e) => {
+            tracing::debug!("Failed to fetch pool asset approval for asset {asset_id}: {e:?}");
+            return Ok(None);
+        }
     };
 
     let raw_bytes = value.into_bytes();

--- a/crates/server/src/handlers/runtime_queries/referenda.rs
+++ b/crates/server/src/handlers/runtime_queries/referenda.rs
@@ -124,7 +124,10 @@ pub async fn get_referendum_info(
 
     match result {
         Ok(val) => val.decode().ok(),
-        Err(_) => None,
+        Err(e) => {
+            tracing::debug!("Failed to fetch referendum info: {e:?}");
+            None
+        }
     }
 }
 
@@ -144,7 +147,10 @@ pub async fn iter_referenda_batch(
                 let result = client.storage().fetch(storage_addr, (ref_id,)).await;
                 let decoded: Option<ReferendumStatus> = match result {
                     Ok(val) => val.decode().ok(),
-                    Err(_) => None,
+                    Err(e) => {
+                        tracing::debug!("Failed to fetch referendum {ref_id} in batch: {e:?}");
+                        None
+                    }
                 };
                 (ref_id, decoded)
             }

--- a/crates/server/src/handlers/runtime_queries/staking.rs
+++ b/crates/server/src/handlers/runtime_queries/staking.rs
@@ -1546,7 +1546,10 @@ pub async fn iter_staking_validators(
     while let Some(entry_result) = stream.next().await {
         let entry = match entry_result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to read validator prefs storage entry: {e:?}");
+                continue;
+            }
         };
 
         let key_bytes = entry.key_bytes();
@@ -1594,7 +1597,10 @@ pub async fn iter_era_stakers_overview_keys(
     while let Some(entry_result) = stream.next().await {
         let entry = match entry_result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to read era stakers overview storage entry: {e:?}");
+                continue;
+            }
         };
 
         let key_bytes = entry.key_bytes();
@@ -1653,7 +1659,10 @@ pub async fn iter_unapplied_slashes(
 
     let mut stream = match client_at_block.storage().iter(storage_addr, ()).await {
         Ok(s) => s,
-        Err(_) => return vec![],
+        Err(e) => {
+            tracing::debug!("Failed to iterate unapplied slashes storage: {e:?}");
+            return vec![];
+        }
     };
 
     let mut result = Vec::new();
@@ -1661,7 +1670,10 @@ pub async fn iter_unapplied_slashes(
     while let Some(entry_result) = stream.next().await {
         let entry = match entry_result {
             Ok(e) => e,
-            Err(_) => continue,
+            Err(e) => {
+                tracing::debug!("Failed to read unapplied slashes storage entry: {e:?}");
+                continue;
+            }
         };
 
         let key_bytes = entry.key_bytes();
@@ -1678,7 +1690,10 @@ pub async fn iter_unapplied_slashes(
         let slashes: Vec<UnappliedSlashStorage> =
             match Vec::<UnappliedSlashStorage>::decode(&mut &value_bytes[..]) {
                 Ok(s) => s,
-                Err(_) => continue,
+                Err(e) => {
+                    tracing::debug!("Failed to decode unapplied slashes value: {e:?}");
+                    continue;
+                }
             };
 
         for slash in slashes {

--- a/crates/server/src/handlers/transaction/material.rs
+++ b/crates/server/src/handlers/transaction/material.rs
@@ -432,7 +432,8 @@ async fn material_versioned_internal(
                 })
                 .unwrap_or_default()
         }
-        Err(_) => {
+        Err(e) => {
+            tracing::debug!("Failed to call metadata_versions runtime API: {e:?}");
             return Err(MaterialError::MetadataVersionsApiNotAvailable);
         }
     };

--- a/crates/server/src/middleware/rc_format.rs
+++ b/crates/server/src/middleware/rc_format.rs
@@ -107,7 +107,10 @@ async fn process_rc_request(
     let (parts, body) = response.into_parts();
     let bytes = match body.collect().await {
         Ok(collected) => collected.to_bytes().to_vec(),
-        Err(_) => return Err(Response::from_parts(parts, Body::empty())),
+        Err(e) => {
+            tracing::debug!("Failed to collect response body: {e:?}");
+            return Err(Response::from_parts(parts, Body::empty()));
+        }
     };
 
     Ok((parts, bytes, at_param))

--- a/crates/server/src/utils/rc_block.rs
+++ b/crates/server/src/utils/rc_block.rs
@@ -198,7 +198,10 @@ fn extract_ah_block_from_candidate_included(
 
     let para_id = match extract_para_id_from_candidate_receipt(candidate_receipt) {
         Ok(id) => id,
-        Err(_) => return None,
+        Err(e) => {
+            tracing::debug!("Failed to extract para ID from candidate receipt: {e:?}");
+            return None;
+        }
     };
 
     if para_id != target_para_id {


### PR DESCRIPTION
Replaces silent errors with debugging logs, to facilitate debugging.

Exceptions:

- `crates/server/src/handlers/runtime_queries/foreign_assets.rs`: Error is expected behavior when not finding the pallet, not indicative of an actual error.
- `crates/server/src/logging/format.rs`: Logging a logger error can turn into a recursive loop.
- `crates/server/src/middleware/rc_format.rs`: `Err(_)` occurrence inside of a test.   

Closes #276 