### PR TITLE
fix: `NotAStashAccount` error not implemented

### DIFF
--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -315,6 +315,9 @@ impl From<crate::handlers::common::accounts::ProxyQueryError> for AccountsError 
 impl From<crate::handlers::common::accounts::StakingQueryError> for AccountsError {
     fn from(err: crate::handlers::common::accounts::StakingQueryError) -> Self {
         match err {
+            crate::handlers::common::accounts::StakingQueryError::NotAStashAccount => {
+                AccountsError::NotAStashAccount
+            }
             crate::handlers::common::accounts::StakingQueryError::BadStakingBlock(msg) => {
                 AccountsError::BadStakingBlock(msg)
             }


### PR DESCRIPTION
`NotAStashAccount` was not included in the `From` impl, so it was defaulting to a `500` error instead of the appropiate `400`.