### PR TITLE
fix: remove serde_json::value from transaction endpoints

### DIFF
--- a/crates/server/src/handlers/transaction/dry_run.rs
+++ b/crates/server/src/handlers/transaction/dry_run.rs
@@ -6,7 +6,6 @@ use crate::utils::BlockId;
 use axum::{Json, extract::State, http::StatusCode, response::IntoResponse};
 use scale_value::{Composite, ValueDef};
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use sp_core::crypto::Ss58Codec;
 use thiserror::Error;
 
@@ -22,7 +21,7 @@ pub struct DryRunRequest {
 #[serde(rename_all = "camelCase")]
 pub struct DryRunResponse {
     pub result_type: String,
-    pub result: Value,
+    pub result: scale_value::Value<()>,
 }
 
 #[derive(Debug, Serialize)]
@@ -390,10 +389,6 @@ fn parse_result_to_response(
     _tx: &str,
 ) -> Result<Json<DryRunResponse>, DryRunError> {
     // The result from DryRunApi is Result<CallDryRunEffects, XcmDryRunApiError>
-    // Convert scale_value::Value to serde_json::Value for the response
-    fn to_json(v: &scale_value::Value<()>) -> Value {
-        serde_json::to_value(v).unwrap_or(Value::Null)
-    }
 
     // Helper to get first value from a Composite
     fn get_first_value(composite: &Composite<()>) -> Option<&scale_value::Value<()>> {
@@ -431,15 +426,15 @@ fn parse_result_to_response(
                     return match exec_variant.name.as_str() {
                         "Ok" => Ok(Json(DryRunResponse {
                             result_type: "DispatchOutcome".to_string(),
-                            result: to_json(inner_value),
+                            result: inner_value.clone(),
                         })),
                         "Err" => Ok(Json(DryRunResponse {
                             result_type: "DispatchError".to_string(),
-                            result: to_json(inner_value),
+                            result: inner_value.clone(),
                         })),
                         _ => Ok(Json(DryRunResponse {
                             result_type: "DispatchOutcome".to_string(),
-                            result: to_json(ok_value),
+                            result: ok_value.clone(),
                         })),
                     };
                 };
@@ -449,7 +444,7 @@ fn parse_result_to_response(
                 let err_value = get_first_value(&variant.values).unwrap_or(&result);
                 return Ok(Json(DryRunResponse {
                     result_type: "TransactionValidityError".to_string(),
-                    result: to_json(err_value),
+                    result: err_value.clone(),
                 }));
             }
             _ => {}
@@ -459,20 +454,33 @@ fn parse_result_to_response(
     // If the structure doesn't match expected format, return as-is
     Ok(Json(DryRunResponse {
         result_type: "DispatchOutcome".to_string(),
-        result: to_json(&result),
+        result,
     }))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::json;
+    use scale_value::{Composite, ValueDef};
 
     #[test]
     fn test_dry_run_response_serialization() {
+        let result = scale_value::Value {
+            value: ValueDef::Composite(Composite::Named(vec![(
+                "paysFee".to_string(),
+                scale_value::Value {
+                    value: ValueDef::Variant(scale_value::Variant {
+                        name: "Yes".to_string(),
+                        values: Composite::Unnamed(vec![]),
+                    }),
+                    context: (),
+                },
+            )])),
+            context: (),
+        };
         let response = DryRunResponse {
             result_type: "DispatchOutcome".to_string(),
-            result: json!({ "actualWeight": { "refTime": "1000", "proofSize": "2000" }, "paysFee": "Yes" }),
+            result,
         };
         let json = serde_json::to_value(&response).unwrap();
         assert_eq!(json["resultType"], "DispatchOutcome");

--- a/crates/server/src/handlers/transaction/dry_run.rs
+++ b/crates/server/src/handlers/transaction/dry_run.rs
@@ -315,39 +315,112 @@ async fn dry_run_internal(
         }
     };
 
-    // Build origin: { System: { Signed: account } }
     let sender_bytes = decode_ss58_address(sender).map_err(|e| DryRunError::ParseFailed {
         transaction: tx.to_string(),
         cause: e.clone(),
         stack: format!("Error: {}\n    at dry_run", e),
     })?;
 
-    let origin = subxt::dynamic::Value::named_composite([(
-        "System",
-        subxt::dynamic::Value::named_composite([(
-            "Signed",
-            subxt::dynamic::Value::from_bytes(sender_bytes),
-        )]),
-    )]);
-
-    // Decode transaction bytes
     let tx_bytes =
         hex::decode(tx.strip_prefix("0x").unwrap_or(tx)).map_err(|e| DryRunError::ParseFailed {
             transaction: tx.to_string(),
             cause: format!("Invalid hex encoding: {}", e),
             stack: format!("Error: Invalid hex encoding: {}\n    at dry_run", e),
         })?;
-    let call = subxt::dynamic::Value::from_bytes(tx_bytes);
 
-    // Call DryRunApi.dry_run_call(origin, call)
-    let method = subxt::dynamic::runtime_api_call::<_, scale_value::Value<()>>(
-        "DryRunApi",
-        "dry_run_call",
-        (origin, call),
+    let metadata = client_at.metadata();
+    let extrinsic_info = frame_decode::extrinsics::decode_extrinsic(
+        &mut &tx_bytes[..],
+        &*metadata,
+        metadata.types(),
+    )
+    .map_err(|e| {
+        let cause = format!("Failed to decode extrinsic: {}", e);
+        DryRunError::ParseFailed {
+            transaction: tx.to_string(),
+            cause: cause.clone(),
+            stack: format!("Error: {}\n    at dry_run", cause),
+        }
+    })?;
+    let call_bytes = &tx_bytes[extrinsic_info.call_data_range()];
+
+    let dry_run_api = metadata
+        .runtime_api_trait_by_name("DryRunApi")
+        .ok_or_else(|| DryRunError::DryRunApiNotAvailable {
+            transaction: tx.to_string(),
+        })?;
+    let dry_run_method = dry_run_api.method_by_name("dry_run_call").ok_or_else(|| {
+        DryRunError::DryRunApiNotAvailable {
+            transaction: tx.to_string(),
+        }
+    })?;
+    let inputs: Vec<_> = dry_run_method.inputs().collect();
+
+    let mut params = Vec::new();
+
+    let origin = scale_value::Value::unnamed_variant(
+        "system",
+        [scale_value::Value::unnamed_variant(
+            "Signed",
+            [subxt::dynamic::Value::from_bytes(sender_bytes)],
+        )],
     );
-    let result = client_at.runtime_apis().call(method).await?;
+    scale_value::scale::encode_as_type(&origin, inputs[0].id, metadata.types(), &mut params)
+        .map_err(|e| {
+            let cause = format!("Failed to encode origin: {}", e);
+            DryRunError::DryRunFailed {
+                transaction: tx.to_string(),
+                cause: cause.clone(),
+                stack: format!("Error: {}\n    at dry_run", cause),
+            }
+        })?;
 
-    parse_result_to_response(result, tx)
+    params.extend_from_slice(call_bytes);
+
+    let xcm_version_addr = subxt::dynamic::constant::<u32>("PolkadotXcm", "AdvertisedXcmVersion");
+    let xcm_version =
+        client_at
+            .constants()
+            .entry(xcm_version_addr)
+            .map_err(|e| DryRunError::DryRunFailed {
+                transaction: tx.to_string(),
+                cause: format!("Failed to fetch AdvertisedXcmVersion: {}", e),
+                stack: format!(
+                    "Error: Failed to fetch AdvertisedXcmVersion: {}\n    at dry_run",
+                    e
+                ),
+            })?;
+    params.extend_from_slice(&xcm_version.to_le_bytes());
+
+    let result_bytes = client_at
+        .runtime_apis()
+        .call_raw("DryRunApi_dry_run_call", Some(&params))
+        .await
+        .map_err(|e| {
+            let cause = e.to_string();
+            DryRunError::DryRunFailed {
+                transaction: tx.to_string(),
+                cause: cause.clone(),
+                stack: format!("Error: {}\n    at dry_run", cause),
+            }
+        })?;
+
+    let return_type_id = dry_run_method.output_ty();
+    let result = scale_value::scale::decode_as_type(
+        &mut &result_bytes[..],
+        return_type_id,
+        metadata.types(),
+    )
+    .map_err(|e| {
+        let cause = format!("Failed to decode dry-run result: {}", e);
+        DryRunError::DryRunFailed {
+            transaction: tx.to_string(),
+            cause: cause.clone(),
+            stack: format!("Error: {}\n    at dry_run", cause),
+        }
+    })?;
+
+    parse_result_to_response(result.remove_context(), tx)
 }
 
 fn validate_sender<'a>(sender: &'a Option<String>, tx: &str) -> Result<&'a str, DryRunError> {

--- a/crates/server/src/handlers/transaction/material.rs
+++ b/crates/server/src/handlers/transaction/material.rs
@@ -13,7 +13,6 @@ use axum::{
 use parity_scale_codec::Decode;
 use scale_decode::DecodeAsType;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use thiserror::Error;
 
 // ================================================================================================
@@ -52,6 +51,22 @@ pub struct At {
     pub height: String,
 }
 
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum Metadata {
+    Hex(String),
+    Structured(Box<frame_metadata::RuntimeMetadataPrefixed>),
+}
+
+impl std::fmt::Debug for Metadata {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Metadata::Hex(s) => f.debug_tuple("Hex").field(s).finish(),
+            Metadata::Structured(_) => f.debug_tuple("Structured").field(&"<metadata>").finish(),
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MaterialResponse {
@@ -62,7 +77,7 @@ pub struct MaterialResponse {
     pub spec_version: String,
     pub tx_version: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<Value>,
+    pub metadata: Option<Metadata>,
 }
 
 #[derive(Debug, Serialize)]
@@ -488,7 +503,7 @@ async fn material_versioned_internal(
                 });
             }
             (MetadataFormat::Scale, Some(bytes)) => {
-                Some(Value::String(format!("0x{}", hex::encode(&bytes))))
+                Some(Metadata::Hex(format!("0x{}", hex::encode(&bytes))))
             }
             (MetadataFormat::Json, Some(bytes)) => {
                 let metadata = frame_metadata::RuntimeMetadataPrefixed::decode(&mut &bytes[..])
@@ -500,15 +515,7 @@ async fn material_versioned_internal(
                         }
                     })?;
 
-                let json = serde_json::to_value(&metadata).map_err(|e| {
-                    let cause = format!("Failed to serialize metadata to JSON: {}", e);
-                    MaterialError::FetchFailed {
-                        cause: cause.clone(),
-                        stack: format!("Error: {}\n    at material (metadata serialize)", cause),
-                    }
-                })?;
-
-                Some(json)
+                Some(Metadata::Structured(Box::new(metadata)))
             }
         }
     } else {
@@ -641,7 +648,7 @@ async fn material_internal(
             })?;
 
         match format {
-            MetadataFormat::Scale => Some(Value::String(metadata_hex)),
+            MetadataFormat::Scale => Some(Metadata::Hex(metadata_hex)),
             MetadataFormat::Json => {
                 // Decode the metadata and convert to JSON
                 let metadata_bytes =
@@ -666,15 +673,7 @@ async fn material_internal(
                             }
                         })?;
 
-                let json = serde_json::to_value(&metadata).map_err(|e| {
-                    let cause = format!("Failed to serialize metadata to JSON: {}", e);
-                    MaterialError::FetchFailed {
-                        cause: cause.clone(),
-                        stack: format!("Error: {}\n    at material (metadata serialize)", cause),
-                    }
-                })?;
-
-                Some(json)
+                Some(Metadata::Structured(Box::new(metadata)))
             }
         }
     } else {
@@ -790,7 +789,7 @@ mod tests {
             spec_name: "test".to_string(),
             spec_version: "1".to_string(),
             tx_version: "1".to_string(),
-            metadata: Some(Value::String("0xmetadata".to_string())),
+            metadata: Some(Metadata::Hex("0xmetadata".to_string())),
         };
         let json = serde_json::to_value(&response).unwrap();
         assert_eq!(json["metadata"], "0xmetadata");


### PR DESCRIPTION
Replacement of #294 .
Also fixes a regression introduced in the dry_run call.