### PR TITLE
fix: decode XCM messages on plain parachains

### DIFF
--- a/crates/server/src/handlers/blocks/decode/xcm.rs
+++ b/crates/server/src/handlers/blocks/decode/xcm.rs
@@ -1205,8 +1205,31 @@ mod tests {
             result.horizontal_messages[0].sent_at.as_deref(),
             Some("30812723")
         );
+
+        // Verify the horizontal message was actually decoded as V5 XCM
+        let hrmp_data_arr = result.horizontal_messages[0]
+            .data
+            .as_array()
+            .expect("horizontal message data should decode to array");
+        assert_eq!(hrmp_data_arr.len(), 1);
+        assert!(
+            hrmp_data_arr[0].as_object().unwrap().contains_key("v5"),
+            "horizontal message should decode as V5 XCM"
+        );
+
         assert_eq!(result.downward_messages.len(), 1);
         assert_eq!(result.downward_messages[0].sent_at, "12345");
+
+        // Verify the downward message was actually decoded as V5 XCM
+        let dmp_data_arr = result.downward_messages[0]
+            .data
+            .as_array()
+            .expect("downward message data should decode to array");
+        assert_eq!(dmp_data_arr.len(), 1);
+        assert!(
+            dmp_data_arr[0].as_object().unwrap().contains_key("v5"),
+            "downward message should decode as V5 XCM"
+        );
     }
 
     /// `inbound_messages_data` envelope must take precedence over native `data`.

--- a/crates/server/src/handlers/blocks/decode/xcm.rs
+++ b/crates/server/src/handlers/blocks/decode/xcm.rs
@@ -379,7 +379,9 @@ impl<'a> XcmDecoder<'a> {
     }
 
     /// Decode XCM messages from parachain extrinsics.
-    /// Looks for `parachainSystem.setValidationData` and extracts downward/horizontal messages.
+    /// Looks for `parachainSystem.setValidationData` and extracts downward/horizontal
+    /// messages from either the `inbound_messages_data` envelope (system chains) or
+    /// the native `data` argument (plain parachains).
     fn decode_parachain_messages(&self) -> XcmMessages {
         let mut messages = XcmMessages::default();
 
@@ -390,97 +392,173 @@ impl<'a> XcmDecoder<'a> {
                 continue;
             }
 
-            let Some(inbound_data) = extrinsic.args.get("inbound_messages_data") else {
-                continue;
-            };
+            if let Some(inbound) = extrinsic.args.get("inbound_messages_data") {
+                self.collect_inbound_envelope(inbound, &mut messages);
+            } else if let Some(data) = extrinsic.args.get("data") {
+                self.collect_native_inherent(data, &mut messages);
+            }
+        }
 
-            // Extract downward messages
-            if let Some(downward) = inbound_data.get("downwardMessages")
-                && let Some(full_msgs) = downward.get("fullMessages").and_then(|v| v.as_array())
-            {
-                for msg in full_msgs {
-                    let sent_at = msg
+        messages
+    }
+
+    /// System-chain `inbound_messages_data` envelope.
+    fn collect_inbound_envelope(&self, inbound_data: &Value, messages: &mut XcmMessages) {
+        // Extract downward messages
+        if let Some(downward) = inbound_data.get("downwardMessages")
+            && let Some(full_msgs) = downward.get("fullMessages").and_then(|v| v.as_array())
+        {
+            for msg in full_msgs {
+                let sent_at = msg
+                    .get("sentAt")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("0")
+                    .to_string();
+                let msg_hex = msg
+                    .get("msg")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                if !msg_hex.is_empty() {
+                    messages.downward_messages.push(DownwardMessage {
+                        sent_at,
+                        msg: msg_hex.clone(),
+                        data: decode_xcm_message(&msg_hex),
+                    });
+                }
+            }
+        }
+
+        // Extract horizontal messages
+        if let Some(horizontal) = inbound_data.get("horizontalMessages")
+            && let Some(full_msgs) = horizontal.get("fullMessages").and_then(|v| v.as_array())
+        {
+            for msg in full_msgs {
+                // HRMP fullMessages are tuples: [originParaId, { sentAt, data }]
+                let (origin_para_id, sent_at, msg_data) = if let Some(tuple) = msg.as_array()
+                    && tuple.len() == 2
+                {
+                    let origin = tuple[0].as_str().unwrap_or("0").to_string();
+                    let inner = &tuple[1];
+                    let sent = inner
                         .get("sentAt")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let data = inner
+                        .get("data")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    (origin, sent, data)
+                } else {
+                    // Fallback: object format
+                    let origin = msg
+                        .get("originParaId")
                         .and_then(|v| v.as_str())
                         .unwrap_or("0")
                         .to_string();
-                    let msg_hex = msg
-                        .get("msg")
+                    let sent = msg
+                        .get("sentAt")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let data = msg
+                        .get("data")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    (origin, sent, data)
+                };
+
+                // Apply paraId filter if specified
+                if self
+                    .para_id_filter
+                    .is_some_and(|filter| origin_para_id != filter.to_string())
+                {
+                    continue;
+                }
+
+                if !msg_data.is_empty() {
+                    messages.horizontal_messages.push(HorizontalMessage {
+                        origin_para_id,
+                        destination_para_id: None,
+                        sent_at,
+                        data: decode_xcm_message(&msg_data),
+                    });
+                }
+            }
+        }
+    }
+
+    /// Native `ParachainInherentData` shape used by plain parachains.
+    fn collect_native_inherent(&self, data: &Value, messages: &mut XcmMessages) {
+        if let Some(arr) = data.get("downwardMessages").and_then(|v| v.as_array()) {
+            for msg in arr {
+                let sent_at = msg
+                    .get("sentAt")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("0")
+                    .to_string();
+                let msg_hex = msg
+                    .get("msg")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                if !msg_hex.is_empty() {
+                    messages.downward_messages.push(DownwardMessage {
+                        sent_at,
+                        msg: msg_hex.clone(),
+                        data: decode_xcm_message(&msg_hex),
+                    });
+                }
+            }
+        }
+
+        // Horizontal: array of [paraId, [ { sentAt, data } ]]
+        if let Some(arr) = data.get("horizontalMessages").and_then(|v| v.as_array()) {
+            for entry in arr {
+                let Some(tuple) = entry.as_array() else {
+                    continue;
+                };
+                if tuple.len() != 2 {
+                    continue;
+                }
+
+                let origin_para_id = tuple[0].as_str().unwrap_or("0").to_string();
+
+                // Apply paraId filter if specified
+                if self
+                    .para_id_filter
+                    .is_some_and(|filter| origin_para_id != filter.to_string())
+                {
+                    continue;
+                }
+                let Some(inner_msgs) = tuple[1].as_array() else {
+                    continue;
+                };
+                for m in inner_msgs {
+                    let sent_at = m
+                        .get("sentAt")
+                        .and_then(|v| v.as_str())
+                        .map(|s| s.to_string());
+                    let data_hex = m
+                        .get("data")
                         .and_then(|v| v.as_str())
                         .unwrap_or("")
                         .to_string();
 
-                    if !msg_hex.is_empty() {
-                        messages.downward_messages.push(DownwardMessage {
-                            sent_at,
-                            msg: msg_hex.clone(),
-                            data: decode_xcm_message(&msg_hex),
-                        });
-                    }
-                }
-            }
-
-            // Extract horizontal messages
-            if let Some(horizontal) = inbound_data.get("horizontalMessages")
-                && let Some(full_msgs) = horizontal.get("fullMessages").and_then(|v| v.as_array())
-            {
-                for msg in full_msgs {
-                    // HRMP fullMessages are tuples: [originParaId, { sentAt, data }]
-                    let (origin_para_id, sent_at, msg_data) = if let Some(tuple) = msg.as_array()
-                        && tuple.len() == 2
-                    {
-                        let origin = tuple[0].as_str().unwrap_or("0").to_string();
-                        let inner = &tuple[1];
-                        let sent = inner
-                            .get("sentAt")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-                        let data = inner
-                            .get("data")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        (origin, sent, data)
-                    } else {
-                        // Fallback: object format
-                        let origin = msg
-                            .get("originParaId")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("0")
-                            .to_string();
-                        let sent = msg
-                            .get("sentAt")
-                            .and_then(|v| v.as_str())
-                            .map(|s| s.to_string());
-                        let data = msg
-                            .get("data")
-                            .and_then(|v| v.as_str())
-                            .unwrap_or("")
-                            .to_string();
-                        (origin, sent, data)
-                    };
-
-                    // Apply paraId filter if specified
-                    if self
-                        .para_id_filter
-                        .is_some_and(|filter| origin_para_id != filter.to_string())
-                    {
-                        continue;
-                    }
-
-                    if !msg_data.is_empty() {
+                    if !data_hex.is_empty() {
                         messages.horizontal_messages.push(HorizontalMessage {
-                            origin_para_id,
+                            origin_para_id: origin_para_id.clone(),
                             destination_para_id: None,
                             sent_at,
-                            data: decode_xcm_message(&msg_data),
+                            data: decode_xcm_message(&data_hex),
                         });
                     }
                 }
             }
         }
-
-        messages
     }
 }
 
@@ -1091,5 +1169,77 @@ mod tests {
         // Valid V5 discriminant but truncated payload
         let result = decode_xcm_message("0x0504");
         assert!(result.is_string(), "truncated XCM should return raw hex");
+    }
+
+    /// Plain parachains expose inbound XCM in the native `data` argument
+    /// (no `inbound_messages_data` envelope). Regression test for #322.
+    #[test]
+    fn test_parachain_native_inherent_horizontal_message_decoded() {
+        let inner = xcm_v5::Xcm::<()>(vec![xcm_v5::Instruction::ClearOrigin]);
+        let xcm_hex = encode_versioned_xcm(VersionedXcm::V5(inner));
+        let hrmp_msg_hex = format!("0x00{}", xcm_hex.trim_start_matches("0x"));
+
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "data".to_string(),
+            serde_json::json!({
+                "downwardMessages": [
+                    { "sentAt": "12345", "msg": xcm_hex }
+                ],
+                "horizontalMessages": [
+                    ["1000", []],
+                    ["2030", [
+                        { "sentAt": "30812723", "data": hrmp_msg_hex }
+                    ]],
+                ]
+            }),
+        );
+
+        let extrinsics = vec![build_parachain_system_extrinsic(args)];
+        let decoder = XcmDecoder::new(ChainType::Parachain, &extrinsics, None);
+        let result = decoder.decode();
+
+        assert_eq!(result.horizontal_messages.len(), 1);
+        assert_eq!(result.horizontal_messages[0].origin_para_id, "2030");
+        assert_eq!(
+            result.horizontal_messages[0].sent_at.as_deref(),
+            Some("30812723")
+        );
+        assert_eq!(result.downward_messages.len(), 1);
+        assert_eq!(result.downward_messages[0].sent_at, "12345");
+    }
+
+    /// `inbound_messages_data` envelope must take precedence over native `data`.
+    #[test]
+    fn test_inbound_envelope_takes_precedence_over_native_data() {
+        let inner = xcm_v5::Xcm::<()>(vec![xcm_v5::Instruction::ClearOrigin]);
+        let xcm_hex = encode_versioned_xcm(VersionedXcm::V5(inner));
+        let hrmp_msg_hex = format!("0x00{}", xcm_hex.trim_start_matches("0x"));
+        let envelope_msg = serde_json::json!(["3000", { "sentAt": "111", "data": hrmp_msg_hex }]);
+
+        let mut args = serde_json::Map::new();
+        args.insert(
+            "inbound_messages_data".to_string(),
+            serde_json::json!({
+                "downwardMessages": { "fullMessages": [], "hashedMessages": [] },
+                "horizontalMessages": { "fullMessages": [envelope_msg], "hashedMessages": [] }
+            }),
+        );
+        args.insert(
+            "data".to_string(),
+            serde_json::json!({
+                "downwardMessages": [],
+                "horizontalMessages": [
+                    ["9999", [{ "sentAt": "999", "data": "0xdead" }]]
+                ]
+            }),
+        );
+
+        let extrinsics = vec![build_parachain_system_extrinsic(args)];
+        let decoder = XcmDecoder::new(ChainType::AssetHub, &extrinsics, None);
+        let result = decoder.decode();
+
+        assert_eq!(result.horizontal_messages.len(), 1);
+        assert_eq!(result.horizontal_messages[0].origin_para_id, "3000");
     }
 }


### PR DESCRIPTION
Fixes #322.

This PR fixes XCM message decoding on plain parachain sidecars (Hydration, Moonbeam, Astar, Acala, Mythos, …). Previously, `decodedXcmMsgs` returned empty arrays for every inbound HRMP and DMP message on any non-system parachain. This was confirmed across all 10 Subscan-verified XCM blocks listed in the ticket.

- **Pre-fix:** 0/10 destination blocks returned decoded XCM data
- **Post-fix:** decoded payloads are produced wherever the chain actually has inbound messages (verified live on Moonbeam #15232406 and Astar #13007294)

## Root cause

PR #305 (`fix: decode XCM messages on system chains`) wired up decoding by reading from a synthetic top-level extrinsic argument `inbound_messages_data`, which is only ever populated for system chains (Asset Hub, BridgeHub, People, Coretime).

For plain parachains, that argument does not exist. Inbound HRMP and DMP live in the **native** `parachainSystem.setValidationData` call argument under `args.data.{horizontalMessages,downwardMessages}` with a different shape:

- `data.downwardMessages: [ { sentAt, msg } ]`
- `data.horizontalMessages: [ [ paraId, [ { sentAt, data } ] ] ]`

`XcmDecoder::decode_parachain_messages` bailed out the moment `inbound_messages_data` was absent, so the entire extrinsic was skipped and every array came back empty. No raw hex, no error — just silently dropped.

## Changes made

All changes in a single file — `crates/server/src/handlers/blocks/decode/xcm.rs`:

1. **Added native `data` fallback** — when `inbound_messages_data` is missing, decode HRMP/DMP from `args.data.{horizontalMessages,downwardMessages}` using the on-wire `ParachainInherentData` shape that all plain parachains emit.
2. **Split the existing logic** into `collect_inbound_envelope` (system-chain shape) and `collect_native_inherent` (plain-parachain shape) so the two paths are explicit and independently testable. Envelope still takes precedence when both are present.
3. **Preserved every existing behaviour** — XCMP `0x00` prefix stripping, `build_xcm_registry` decoding, raw-hex graceful fallback, `para_id_filter`, and the relay-chain `paraInherent.enter` path are untouched.

Net diff: **+221 / −71** in one file, no new dependencies.

## Tests

22 unit tests passing (20 existing + 2 new):

- `test_parachain_native_inherent_horizontal_message_decoded` — regression test for the bug, asserts a real V5 HRMP payload in native shape decodes
- `test_inbound_envelope_takes_precedence_over_native_data` — guarantees system-chain behaviour is preserved when both shapes are present

## Verification

Tested locally against the bug-report blocks using public parachain RPCs:

| Chain | Block | Pre-fix | Post-fix |
|---|---|---|---|
| Moonbeam (2004) | 15232406 | EMPTY | 1 HRMP from para 2030, decoded as V5 (`withdrawAsset` → `buyExecution` → …) |
| Astar (2006) | 13007294 | EMPTY | 1 HRMP from para 2030, decoded as V5 |
| Hydration (2034) | 12099098 | EMPTY | `[]` (chain genuinely has every HRMP slot empty at this height — decoder is now reading them, just finding nothing) |
| Asset Hub (1000) | 14586932 (regression check) | 1 HRMP | 1 HRMP — no regression |

Acala (2000) and Mythos (3369) blocks share the exact same code path; the unit test covers their JSON shape one-to-one. Live confirmation on those two will happen once the new binary is rolled out to the internal Cloud Run deployments.
