### PR TITLE
fix(docker): correct image name to paritytech/ and publish latest tag

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       VERSION: ${{ steps.version.outputs.VERSION }}
       DATE_TAG: ${{ steps.version.outputs.DATE_TAG }}
+      IS_LATEST: ${{ steps.version.outputs.IS_LATEST }}
     steps:
       - name: Define version
         id: version
@@ -39,6 +40,14 @@ jobs:
             echo "VERSION=${REF_SLUG}-${COMMIT_SHA_SHORT}" >> $GITHUB_OUTPUT
           else
             echo "VERSION=${REF_SLUG}" >> $GITHUB_OUTPUT
+          fi
+          # Tag `latest` only for version tag builds (refs/tags/v*), never for
+          # main/branch builds, so `latest` always points at a released version.
+          if [[ "${{ github.ref_type }}" == "tag" && "${REF_NAME}" == v* ]]
+          then
+            echo "IS_LATEST=true" >> $GITHUB_OUTPUT
+          else
+            echo "IS_LATEST=false" >> $GITHUB_OUTPUT
           fi
 
   build_docker:
@@ -107,6 +116,7 @@ jobs:
     env:
       VERSION: ${{ needs.set-variables.outputs.VERSION }}
       DATE_TAG: ${{ needs.set-variables.outputs.DATE_TAG }}
+      IS_LATEST: ${{ needs.set-variables.outputs.IS_LATEST }}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v4
@@ -127,7 +137,12 @@ jobs:
       - name: Create manifest list and push
         working-directory: /tmp/digests
         run: |
+          IMAGE=docker.io/paritytech/polkadot-rest-api
+          TAGS=(-t "${IMAGE}:${VERSION}" -t "${IMAGE}:${DATE_TAG}")
+          # Only tag `latest` on version tag builds (see set-variables job).
+          if [[ "${IS_LATEST}" == "true" ]]; then
+            TAGS+=(-t "${IMAGE}:latest")
+          fi
           docker buildx imagetools create \
-            -t docker.io/paritytech/polkadot-rest-api:${{ env.VERSION }} \
-            -t docker.io/paritytech/polkadot-rest-api:${{ env.DATE_TAG }} \
-            $(printf 'docker.io/paritytech/polkadot-rest-api@sha256:%s ' *)
+            "${TAGS[@]}" \
+            $(printf "${IMAGE}@sha256:%s " *)

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ARG VCS_REF=main
 ARG BUILD_DATE=""
 
 LABEL summary="Polkadot REST API." \
-	name="parity/polkadot-rest-api" \
+	name="paritytech/polkadot-rest-api" \
 	maintainer="devops-team@parity.io" \
 	version="${VERSION}" \
 	description="Polkadot REST API - Rust implementation of Substrate API Sidecar." \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
 
   rest-api:
     container_name: rest-api
-    image: docker.io/parity/polkadot-rest-api:latest
+    image: docker.io/paritytech/polkadot-rest-api:latest
     build: .
     read_only: true
     restart: on-failure

--- a/docs/guides/ADVANCED_CONFIG.md
+++ b/docs/guides/ADVANCED_CONFIG.md
@@ -287,16 +287,16 @@ The final image runs as the `nobody` user and includes these defaults:
 
 ```bash
 # Pull the image
-docker pull docker.io/parity/polkadot-rest-api:latest
+docker pull docker.io/paritytech/polkadot-rest-api:latest
 
 # Run with defaults (connects to host node)
 docker run --rm -it --read-only -p 8080:8080 \
   -e SAS_SUBSTRATE_URL=ws://host.docker.internal:9944 \
-  parity/polkadot-rest-api
+  paritytech/polkadot-rest-api
 
 # Run with env file
 docker run --rm -it --read-only --env-file .env.docker -p 8080:8080 \
-  parity/polkadot-rest-api
+  paritytech/polkadot-rest-api
 ```
 
 > **Tip**: Always use `--read-only` for containers in production.
@@ -338,7 +338,7 @@ This starts:
 
 | Change | Details |
 |--------|---------|
-| **Image name** | `parity/substrate-api-sidecar` → `parity/polkadot-rest-api` |
+| **Image name** | `parity/substrate-api-sidecar` → `paritytech/polkadot-rest-api` |
 | **Service name** | `sidecar` → `rest-api` (in docker-compose) |
 | **Base image** | Node.js Alpine → Debian slim (smaller runtime, no Node.js needed) |
 | **Run user** | `node` → `nobody` |

--- a/docs/guides/MIGRATION.md
+++ b/docs/guides/MIGRATION.md
@@ -294,7 +294,7 @@ Both projects provide a `Dockerfile` and `docker-compose.yml`. The compose stack
 | **Base image (build)** | `node:18.12.1-alpine` | `rust:1.90.0-slim-bookworm` |
 | **Base image (runtime)** | `node:18.12.1-alpine` | `debian:bookworm-slim` |
 | **Runtime size** | Includes full Node.js runtime + `node_modules` | Static binary (~single executable) + `ca-certificates` |
-| **Docker Hub** | `parity/substrate-api-sidecar` | `parity/polkadot-rest-api` |
+| **Docker Hub** | `parity/substrate-api-sidecar` | `paritytech/polkadot-rest-api` |
 | **Build command** | `yarn build:docker` | `docker build .` |
 | **Run user** | `node` | `nobody` |
 | **Default env vars** | `SAS_EXPRESS_PORT=8080`, `SAS_EXPRESS_BIND_HOST=0.0.0.0` | `SAS_EXPRESS_PORT=8080`, `SAS_EXPRESS_BIND_HOST=0.0.0.0`, `RUST_LOG=info` |
@@ -307,7 +307,7 @@ docker pull docker.io/parity/substrate-api-sidecar:latest
 docker run --rm -it --read-only -p 8080:8080 substrate-api-sidecar
 
 # Polkadot REST API
-docker pull docker.io/parity/polkadot-rest-api:latest
+docker pull docker.io/paritytech/polkadot-rest-api:latest
 docker run --rm -it --read-only -p 8080:8080 polkadot-rest-api
 ```
 
@@ -326,7 +326,7 @@ Both compose files include the same services: `polkadot` node, API server, `loki
 
 ### Migration steps for Docker users
 
-1. **Update image name**: Replace `parity/substrate-api-sidecar` with `parity/polkadot-rest-api`
+1. **Update image name**: Replace `parity/substrate-api-sidecar` with `paritytech/polkadot-rest-api`
 2. **Update service name** (if referenced): `sidecar` → `rest-api` (or your preferred name)
 3. **Remove `SAS_EXPRESS_BIND_HOST`** from environment if set to `0.0.0.0` — this is now the Dockerfile default
 4. **Update health checks**: Change `curl http://localhost:8080/blocks/head` to `curl http://localhost:8080/v1/blocks/head` (note the `/v1` prefix)


### PR DESCRIPTION
Fixes #331

  ### Problem
  
  The docs, Dockerfile label, and `docker-compose.yml` all reference `parity/polkadot-rest-api`, but the image is actually published under **`paritytech/polkadot-rest-api`**. The `parity/...` repo doesn't exist on Docker Hub, so users following
  the documentation hit:

  ```
  $ docker pull docker.io/parity/polkadot-rest-api:latest
  Error response from daemon: pull access denied for parity/polkadot-rest-api,
  repository does not exist or may require 'docker login': denied
  ```

  There was also a second problem: the deploy workflow only pushed `:VERSION` and `:DATE_TAG` tags and **never `:latest`** — so even with the corrected image name, `docker pull paritytech/polkadot-rest-api` (which defaults to `:latest`) would
  still fail with `manifest unknown`.

  ### Changes

  **Image name `parity/` → `paritytech/`** (4 files):

  | File | Spots |
  |------|-------|
  | `Dockerfile` | OCI `name=` label |
  | `docker-compose.yml` | `rest-api` service `image:` |
  | `docs/guides/MIGRATION.md` | Docker Hub table, `docker pull`, migration step (3) |
  | `docs/guides/ADVANCED_CONFIG.md` | pull cmd, two `docker run` args, image-name table (4) |

  Legitimate `parity/substrate-api-sidecar` references (that image really does live under the `parity` org) were left untouched.

  **Publish a `latest` tag** (`.github/workflows/deploy.yml`):
  - `set-variables` now emits an `IS_LATEST` output, `true` only when the build is a version tag (`github.ref_type == tag && ref_name == v*`).
  - The manifest-push step conditionally appends `-t …:latest`.

  `latest` is tagged **only on version tag releases**, so it always points at a released version and never an unstable `main`-push build — the standard, safe convention.
