### PR TITLE
fix: surface failed asset-balance queries instead of dropping them

### DIFF
--- a/crates/server/src/handlers/accounts/get_asset_balances.rs
+++ b/crates/server/src/handlers/accounts/get_asset_balances.rs
@@ -50,7 +50,7 @@ const MAX_REPORTED_ASSET_ERRORS: usize = 100;
         ("at" = Option<String>, Query, description = "Block hash or number to query at"),
         ("useRcBlock" = Option<bool>, Query, description = "Treat 'at' as relay chain block identifier"),
         ("assets" = Option<String>, Query, description = "Comma-separated list of asset IDs to query"),
-        ("showEmpty" = Option<bool>, Query, description = "When true, include assets with zero balance (default: false)"),
+        ("showEmpty" = Option<bool>, Query, description = "When true, include assets with zero balance (default: false). Even with showEmpty, an asset whose query failed is omitted and listed in `errors` (not returned as zero), so this does not guarantee one entry per requested asset under partial failure."),
         ("strict" = Option<bool>, Query, description = "When true, return 503 if any per-asset query fails instead of a partial 200 (default: false)")
     ),
     responses(
@@ -110,10 +110,13 @@ async fn query_asset_balances(
 
     // Determine which assets to query
     let assets_to_query = if asset_ids.is_empty() {
-        // Query all asset IDs using centralized function
+        // Query all asset IDs using centralized function. The pallet was confirmed
+        // available just above, so a failure here is a transient storage/RPC error,
+        // not a missing pallet — surface it as 503 (retryable) rather than a 400 that
+        // tells the client its request was bad. Detail stays in the server log.
         query_all_assets_id(client_at_block).await.map_err(|e| {
             tracing::warn!("Failed to query all asset IDs: {e}");
-            AccountsError::PalletNotAvailable("Assets".to_string())
+            AccountsError::AssetIdsQueryFailed
         })?
     } else {
         asset_ids.to_vec()

--- a/crates/server/src/handlers/accounts/get_asset_balances.rs
+++ b/crates/server/src/handlers/accounts/get_asset_balances.rs
@@ -18,6 +18,12 @@ use serde_json::json;
 use sp_core::crypto::AccountId32;
 use subxt::{OnlineClientAtBlock, SubstrateConfig};
 
+/// Maximum number of per-asset failures listed in the response `errors` array. The
+/// `partial` flag still reflects whether ANY asset failed; this only bounds how much
+/// detail is returned so a node outage on the "query all assets" path cannot inflate
+/// the response into an unbounded array (issue #342).
+const MAX_REPORTED_ASSET_ERRORS: usize = 100;
+
 // ================================================================================================
 // Main Handler
 // ================================================================================================
@@ -115,8 +121,8 @@ async fn query_asset_balances(
 
     // Query each asset balance in parallel. `errors` holds assets whose per-asset
     // query genuinely failed (issue #342); they are omitted from `assets`.
-    let (assets, errors) =
-        query_assets(client_at_block, account, &assets_to_query, show_empty).await?;
+    let (assets, mut errors) =
+        query_assets(client_at_block, account, &assets_to_query, show_empty).await;
 
     // Strict mode is opt-in: when any asset failed, fail the whole request with a 503
     // instead of returning a partial 200. Default behavior is unchanged.
@@ -124,13 +130,19 @@ async fn query_asset_balances(
         return Err(AccountsError::PartialAssetBalances(errors.len()));
     }
 
+    // `partial` reflects whether ANY asset failed; the per-asset `errors` list is then
+    // capped so a node outage on the "query all assets" path cannot inflate the
+    // response into a huge array (the count behind `partial` is still accurate).
+    let partial = !errors.is_empty();
+    errors.truncate(MAX_REPORTED_ASSET_ERRORS);
+
     Ok(AssetBalancesResponse {
         at: BlockInfo {
             hash: block.hash.clone(),
             height: block.number.to_string(),
         },
         assets,
-        partial: !errors.is_empty(),
+        partial,
         errors,
         rc_block_hash: None,
         rc_block_number: None,

--- a/crates/server/src/handlers/accounts/get_asset_balances.rs
+++ b/crates/server/src/handlers/accounts/get_asset_balances.rs
@@ -31,23 +31,26 @@ use subxt::{OnlineClientAtBlock, SubstrateConfig};
 /// - `useRcBlock` (optional): When true, treat 'at' as relay chain block identifier
 /// - `assets` (optional): List of asset IDs to query (queries all if omitted)
 /// - `showEmpty`  (optional): When true, include assets with zero balance (default: false)
+/// - `strict`     (optional): When true, return 503 if any per-asset query fails instead
+///   of a partial 200 (default: false)
 #[utoipa::path(
     get,
     path = "/v1/accounts/{accountId}/asset-balances",
     tag = "accounts",
     summary = "Account asset balances",
-    description = "Returns asset balances for a given account on Asset Hub chains.",
+    description = "Returns asset balances for a given account on Asset Hub chains. A missing assetId means the account holds none of that asset; when `partial` is true the asset list is incomplete (some per-asset queries failed, see `errors`) and a missing assetId must NOT be treated as a zero balance.",
     params(
         ("accountId" = String, Path, description = "SS58-encoded account address"),
         ("at" = Option<String>, Query, description = "Block hash or number to query at"),
         ("useRcBlock" = Option<bool>, Query, description = "Treat 'at' as relay chain block identifier"),
         ("assets" = Option<String>, Query, description = "Comma-separated list of asset IDs to query"),
-        ("showEmpty" = Option<bool>, Query, description = "When true, include assets with zero balance (default: false)")
+        ("showEmpty" = Option<bool>, Query, description = "When true, include assets with zero balance (default: false)"),
+        ("strict" = Option<bool>, Query, description = "When true, return 503 if any per-asset query fails instead of a partial 200 (default: false)")
     ),
     responses(
-        (status = 200, description = "Account asset balances", body = AssetBalancesResponse),
+        (status = 200, description = "Account asset balances (may be partial; check the `partial` flag)", body = AssetBalancesResponse),
         (status = 400, description = "Invalid parameters"),
-        (status = 503, description = "Service unavailable"),
+        (status = 503, description = "Service unavailable, or strict=true and a per-asset query failed"),
         (status = 500, description = "Internal server error")
     )
 )]
@@ -73,12 +76,14 @@ pub async fn get_asset_balances(
 
     let assets = params.assets.as_deref().unwrap_or(&[]);
     let show_empty = params.show_empty;
+    let strict = params.strict;
     let response = query_asset_balances(
         &client_at_block,
         &account,
         &resolved_block,
         assets,
         show_empty,
+        strict,
     )
     .await?;
     Ok(Json(response).into_response())
@@ -90,6 +95,7 @@ async fn query_asset_balances(
     block: &utils::ResolvedBlock,
     asset_ids: &[u32],
     show_empty: bool,
+    strict: bool,
 ) -> Result<AssetBalancesResponse, AccountsError> {
     // Check if Assets pallet is available using centralized function
     if !assets_queries::is_assets_pallet_available(client_at_block) {
@@ -107,8 +113,16 @@ async fn query_asset_balances(
         asset_ids.to_vec()
     };
 
-    // Query each asset balance in parallel
-    let assets = query_assets(client_at_block, account, &assets_to_query, show_empty).await?;
+    // Query each asset balance in parallel. `errors` holds assets whose per-asset
+    // query genuinely failed (issue #342); they are omitted from `assets`.
+    let (assets, errors) =
+        query_assets(client_at_block, account, &assets_to_query, show_empty).await?;
+
+    // Strict mode is opt-in: when any asset failed, fail the whole request with a 503
+    // instead of returning a partial 200. Default behavior is unchanged.
+    if strict && !errors.is_empty() {
+        return Err(AccountsError::PartialAssetBalances(errors.len()));
+    }
 
     Ok(AssetBalancesResponse {
         at: BlockInfo {
@@ -116,6 +130,8 @@ async fn query_asset_balances(
             height: block.number.to_string(),
         },
         assets,
+        partial: !errors.is_empty(),
+        errors,
         rc_block_hash: None,
         rc_block_number: None,
         ah_timestamp: None,
@@ -160,6 +176,7 @@ async fn handle_use_rc_block(
     // Process each AH block
     let assets = params.assets.as_deref().unwrap_or(&[]);
     let show_empty = params.show_empty;
+    let strict = params.strict;
     let mut results = Vec::new();
     for ah_block in ah_blocks {
         let ah_resolved = utils::ResolvedBlock {
@@ -167,9 +184,15 @@ async fn handle_use_rc_block(
             number: ah_block.number,
         };
         let client_at_block = state.client.at_block(ah_resolved.number).await?;
-        let mut response =
-            query_asset_balances(&client_at_block, &account, &ah_resolved, assets, show_empty)
-                .await?;
+        let mut response = query_asset_balances(
+            &client_at_block,
+            &account,
+            &ah_resolved,
+            assets,
+            show_empty,
+            strict,
+        )
+        .await?;
 
         // Add RC block info
         response.rc_block_hash = Some(rc_block_hash.clone());

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -74,7 +74,7 @@ pub struct AssetBalancesResponse {
     /// True when at least one requested asset could not be fetched/decoded and was
     /// therefore omitted from `assets`. Absent (not serialized) when the result is
     /// complete, so existing clients see no change.
-    #[serde(skip_serializing_if = "is_false")]
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub partial: bool,
 
     /// The assets whose per-asset query failed, with a generic reason. Absent (not
@@ -100,11 +100,6 @@ pub struct AssetBalanceQueryError {
     pub asset_id: String,
     /// Human-readable failure reason (e.g. the underlying RPC error).
     pub reason: String,
-}
-
-/// serde `skip_serializing_if` helper: skip a `bool` field when it is false.
-fn is_false(value: &bool) -> bool {
-    !*value
 }
 
 /// Block information

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -303,6 +303,12 @@ pub enum AccountsError {
     // ---- Asset balance strict-mode error (issue #342) ----
     #[error("Partial result: {0} asset balance(s) could not be fetched")]
     PartialAssetBalances(usize),
+
+    // ---- Asset id enumeration failed (issue #342) ----
+    // Pallet availability is checked before enumeration, so this is a transient
+    // storage/RPC failure, not a client error. Generic message (no internal detail).
+    #[error("failed to enumerate assets on this chain")]
+    AssetIdsQueryFailed,
 }
 
 impl From<StorageError> for AccountsError {
@@ -438,7 +444,8 @@ impl IntoResponse for AccountsError {
             }
             // Strict mode (issue #342): per-asset queries failed (typically transient
             // upstream RPC errors), so report 503 to signal "retry" rather than 500.
-            AccountsError::PartialAssetBalances(_) => {
+            // Asset-id enumeration failure is likewise transient (pallet already checked).
+            AccountsError::PartialAssetBalances(_) | AccountsError::AssetIdsQueryFailed => {
                 (StatusCode::SERVICE_UNAVAILABLE, self.to_string())
             }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -47,6 +47,12 @@ pub struct AssetBalancesQueryParams {
     /// When true, include assets with zero balance. Defaults to false.
     #[serde(default)]
     pub show_empty: bool,
+
+    /// When true, fail the whole request with a 503 if any per-asset query errors,
+    /// instead of returning a partial 200 response. Opt-in (defaults to false) so the
+    /// default behavior stays non-breaking; see issue #342.
+    #[serde(default)]
+    pub strict: bool,
 }
 
 // ================================================================================================
@@ -54,11 +60,27 @@ pub struct AssetBalancesQueryParams {
 // ================================================================================================
 
 /// Response for GET /accounts/{accountId}/asset-balances
+///
+/// Note (issue #342): a missing `assetId` in `assets` means the account holds none
+/// of that asset — it is NOT equivalent to a zero balance when `partial` is true.
+/// If any per-asset query failed, `partial` is true and the failed assets are listed
+/// in `errors`; treat the asset list as incomplete in that case.
 #[derive(Debug, Serialize, ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct AssetBalancesResponse {
     pub at: BlockInfo,
     pub assets: Vec<AssetBalance>,
+
+    /// True when at least one requested asset could not be fetched/decoded and was
+    /// therefore omitted from `assets`. Absent (not serialized) when the result is
+    /// complete, so existing clients see no change.
+    #[serde(skip_serializing_if = "is_false")]
+    pub partial: bool,
+
+    /// The assets whose per-asset query failed, with the reason. Absent (not
+    /// serialized) when empty.
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub errors: Vec<AssetBalanceQueryError>,
 
     // Only present when useRcBlock=true
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -67,6 +89,21 @@ pub struct AssetBalancesResponse {
     pub rc_block_number: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ah_timestamp: Option<String>,
+}
+
+/// A per-asset failure surfaced in `AssetBalancesResponse::errors` (issue #342).
+#[derive(Debug, Clone, Serialize, ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AssetBalanceQueryError {
+    /// Asset ID as string (matches the `assetId` format used elsewhere in the response).
+    pub asset_id: String,
+    /// Human-readable failure reason (e.g. the underlying RPC error).
+    pub reason: String,
+}
+
+/// serde `skip_serializing_if` helper: skip a `bool` field when it is false.
+fn is_false(value: &bool) -> bool {
+    !*value
 }
 
 /// Block information
@@ -261,6 +298,10 @@ pub enum AccountsError {
     // ---- Generic internal error ----
     #[error("Internal error: {0}")]
     InternalError(String),
+
+    // ---- Asset balance strict-mode error (issue #342) ----
+    #[error("Partial result: {0} asset balance(s) could not be fetched")]
+    PartialAssetBalances(usize),
 }
 
 impl From<StorageError> for AccountsError {
@@ -393,6 +434,11 @@ impl IntoResponse for AccountsError {
                 if matches!(inner, RcBlockError::BlockNotFound(_)) =>
             {
                 (StatusCode::BAD_REQUEST, inner.to_string())
+            }
+            // Strict mode (issue #342): per-asset queries failed (typically transient
+            // upstream RPC errors), so report 503 to signal "retry" rather than 500.
+            AccountsError::PartialAssetBalances(_) => {
+                (StatusCode::SERVICE_UNAVAILABLE, self.to_string())
             }
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
@@ -1223,6 +1269,68 @@ mod tests {
         let json = r#"{"assets": [1984, 2000]}"#;
         let params: AssetBalancesQueryParams = serde_json::from_str(json).unwrap();
         assert_eq!(params.assets, Some(vec![1984, 2000]));
+    }
+
+    // --- strict flag + partial response contract (issue #342) ---
+
+    #[test]
+    fn test_asset_balances_query_strict_defaults_false() {
+        let json = r#"{"at": "100"}"#;
+        let params: AssetBalancesQueryParams = serde_json::from_str(json).unwrap();
+        assert!(!params.strict);
+    }
+
+    #[test]
+    fn test_asset_balances_query_accepts_strict() {
+        let json = r#"{"strict": true}"#;
+        let params: AssetBalancesQueryParams = serde_json::from_str(json).unwrap();
+        assert!(params.strict);
+    }
+
+    #[test]
+    fn test_asset_balances_response_omits_partial_and_errors_when_complete() {
+        let response = AssetBalancesResponse {
+            at: BlockInfo {
+                hash: "0xabc".to_string(),
+                height: "100".to_string(),
+            },
+            assets: vec![],
+            partial: false,
+            errors: vec![],
+            rc_block_hash: None,
+            rc_block_number: None,
+            ah_timestamp: None,
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        // Complete results look exactly like before: no new keys for existing clients.
+        assert!(json.get("partial").is_none());
+        assert!(json.get("errors").is_none());
+    }
+
+    #[test]
+    fn test_asset_balances_response_includes_partial_and_errors_when_incomplete() {
+        let response = AssetBalancesResponse {
+            at: BlockInfo {
+                hash: "0xabc".to_string(),
+                height: "100".to_string(),
+            },
+            assets: vec![],
+            partial: true,
+            errors: vec![AssetBalanceQueryError {
+                asset_id: "1337".to_string(),
+                reason: "rpc failure".to_string(),
+            }],
+            rc_block_hash: None,
+            rc_block_number: None,
+            ah_timestamp: None,
+        };
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["partial"], serde_json::json!(true));
+        assert_eq!(json["errors"][0]["assetId"], serde_json::json!("1337"));
+        assert_eq!(
+            json["errors"][0]["reason"],
+            serde_json::json!("rpc failure")
+        );
     }
 
     #[test]

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -77,8 +77,9 @@ pub struct AssetBalancesResponse {
     #[serde(skip_serializing_if = "is_false")]
     pub partial: bool,
 
-    /// The assets whose per-asset query failed, with the reason. Absent (not
-    /// serialized) when empty.
+    /// The assets whose per-asset query failed, with a generic reason. Absent (not
+    /// serialized) when empty, and capped in length — `partial` (not the length of
+    /// this list) is the authoritative "result is incomplete" signal.
     #[serde(skip_serializing_if = "Vec::is_empty")]
     pub errors: Vec<AssetBalanceQueryError>,
 

--- a/crates/server/src/handlers/accounts/utils/assets.rs
+++ b/crates/server/src/handlers/accounts/utils/assets.rs
@@ -6,6 +6,7 @@
 //! This module provides wrapper functions that delegate to the centralized
 //! `runtime_queries::assets` module for storage queries.
 
+use crate::handlers::accounts::types::AssetBalanceQueryError;
 use crate::handlers::accounts::{AccountsError, AssetBalance};
 use crate::handlers::runtime_queries::assets as assets_queries;
 use sp_core::crypto::AccountId32;
@@ -24,14 +25,17 @@ pub async fn query_all_assets_id(
 
 /// Query asset balances for an account.
 ///
-/// Delegates to `runtime_queries::assets::get_asset_balances`.
+/// Delegates to `runtime_queries::assets::get_asset_balances` and returns both the
+/// resolved balances and any per-asset failures. Callers turn a non-empty error list
+/// into a partial-response signal (or a 503 in strict mode) instead of silently
+/// dropping the failed assets — see issue #342.
 pub async fn query_assets(
     client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
     account: &AccountId32,
     assets: &[u32],
     show_empty: bool,
-) -> Result<Vec<AssetBalance>, AccountsError> {
-    let balances = assets_queries::get_asset_balances(client_at_block, account, assets, show_empty)
+) -> Result<(Vec<AssetBalance>, Vec<AssetBalanceQueryError>), AccountsError> {
+    let result = assets_queries::get_asset_balances(client_at_block, account, assets, show_empty)
         .await
         .map_err(|_| {
             AccountsError::DecodeFailed(parity_scale_codec::Error::from(
@@ -39,7 +43,8 @@ pub async fn query_assets(
             ))
         })?;
 
-    Ok(balances
+    let balances = result
+        .balances
         .into_iter()
         .map(|(asset_id, decoded)| AssetBalance {
             asset_id: asset_id.to_string(),
@@ -47,5 +52,16 @@ pub async fn query_assets(
             is_frozen: decoded.is_frozen,
             is_sufficient: decoded.is_sufficient,
         })
-        .collect())
+        .collect();
+
+    let errors = result
+        .errors
+        .into_iter()
+        .map(|e| AssetBalanceQueryError {
+            asset_id: e.asset_id.to_string(),
+            reason: e.reason,
+        })
+        .collect();
+
+    Ok((balances, errors))
 }

--- a/crates/server/src/handlers/accounts/utils/assets.rs
+++ b/crates/server/src/handlers/accounts/utils/assets.rs
@@ -6,8 +6,8 @@
 //! This module provides wrapper functions that delegate to the centralized
 //! `runtime_queries::assets` module for storage queries.
 
+use crate::handlers::accounts::AssetBalance;
 use crate::handlers::accounts::types::AssetBalanceQueryError;
-use crate::handlers::accounts::{AccountsError, AssetBalance};
 use crate::handlers::runtime_queries::assets as assets_queries;
 use sp_core::crypto::AccountId32;
 use subxt::{OnlineClientAtBlock, SubstrateConfig};
@@ -34,14 +34,9 @@ pub async fn query_assets(
     account: &AccountId32,
     assets: &[u32],
     show_empty: bool,
-) -> Result<(Vec<AssetBalance>, Vec<AssetBalanceQueryError>), AccountsError> {
-    let result = assets_queries::get_asset_balances(client_at_block, account, assets, show_empty)
-        .await
-        .map_err(|_| {
-            AccountsError::DecodeFailed(parity_scale_codec::Error::from(
-                "Failed to query asset balances",
-            ))
-        })?;
+) -> (Vec<AssetBalance>, Vec<AssetBalanceQueryError>) {
+    let result =
+        assets_queries::get_asset_balances(client_at_block, account, assets, show_empty).await;
 
     let balances = result
         .balances
@@ -63,5 +58,5 @@ pub async fn query_assets(
         })
         .collect();
 
-    Ok((balances, errors))
+    (balances, errors)
 }

--- a/crates/server/src/handlers/accounts/utils/assets.rs
+++ b/crates/server/src/handlers/accounts/utils/assets.rs
@@ -54,7 +54,7 @@ pub async fn query_assets(
         .into_iter()
         .map(|e| AssetBalanceQueryError {
             asset_id: e.asset_id.to_string(),
-            reason: e.reason,
+            reason: e.reason.to_string(),
         })
         .collect();
 

--- a/crates/server/src/handlers/runtime_queries/assets.rs
+++ b/crates/server/src/handlers/runtime_queries/assets.rs
@@ -82,11 +82,88 @@ pub struct DecodedAssetMetadata {
 }
 
 /// Decoded asset balance for an account.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DecodedAssetBalance {
     pub balance: String,
     pub is_frozen: bool,
     pub is_sufficient: bool,
+}
+
+/// A per-asset failure encountered while fetching balances in bulk.
+///
+/// This represents a *real* failure — an RPC/backend error, or storage that was
+/// present but could not be decoded. It is deliberately distinct from the ordinary
+/// "account holds none of this asset" case, which is an absence (omitted), not an
+/// error. Surfacing these instead of dropping them is the fix for issue #342.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssetBalanceFetchError {
+    pub asset_id: u32,
+    pub reason: String,
+}
+
+/// Result of fetching balances for multiple assets.
+///
+/// `balances` holds the assets we could resolve. `errors` holds the assets whose
+/// per-asset query genuinely failed; a non-empty `errors` lets callers report a
+/// partial result instead of silently omitting the failed assets (issue #342).
+#[derive(Debug, Default)]
+pub struct AssetBalancesResult {
+    pub balances: Vec<(u32, DecodedAssetBalance)>,
+    pub errors: Vec<AssetBalanceFetchError>,
+}
+
+/// Outcome of fetching + decoding a single asset balance, independent of the
+/// storage backend. Mapping the subxt result into this enum at the async boundary
+/// keeps the classification logic (`collect_asset_balances`) pure and unit-testable.
+#[derive(Debug)]
+enum AssetBalanceOutcome {
+    /// Storage entry present and decoded successfully.
+    Decoded(DecodedAssetBalance),
+    /// Account holds no entry for this asset — a legitimate absence, not an error.
+    Absent,
+    /// Fetch or decode failed — a real error we must surface, never a zero balance.
+    Failed(String),
+}
+
+/// Build a zero-balance stub for assets the account does not hold (used when the
+/// caller asked to include empty balances).
+fn zero_balance() -> DecodedAssetBalance {
+    DecodedAssetBalance {
+        balance: "0".to_string(),
+        is_frozen: false,
+        is_sufficient: false,
+    }
+}
+
+/// Turn per-asset outcomes into balances + errors, honoring `show_empty`.
+///
+/// - `Decoded` is included in `balances`.
+/// - `Absent` is included as a zero balance only when `show_empty` is true, otherwise
+///   omitted; it is never an error.
+/// - `Failed` is recorded in `errors` and is **never** turned into a (zero) balance,
+///   so a failed per-asset query can never masquerade as a zero holding — the
+///   ghost-zero class of bug described in issue #342.
+fn collect_asset_balances(
+    outcomes: Vec<(u32, AssetBalanceOutcome)>,
+    show_empty: bool,
+) -> AssetBalancesResult {
+    let mut result = AssetBalancesResult::default();
+    for (asset_id, outcome) in outcomes {
+        match outcome {
+            AssetBalanceOutcome::Decoded(decoded) => result.balances.push((asset_id, decoded)),
+            AssetBalanceOutcome::Absent => {
+                if show_empty {
+                    result.balances.push((asset_id, zero_balance()));
+                }
+            }
+            AssetBalanceOutcome::Failed(reason) => {
+                result
+                    .errors
+                    .push(AssetBalanceFetchError { asset_id, reason });
+            }
+        }
+    }
+    result
 }
 
 /// Decoded asset approval.
@@ -254,69 +331,58 @@ pub async fn get_asset_balances(
     account: &AccountId32,
     asset_ids: &[u32],
     show_empty: bool,
-) -> Result<Vec<(u32, DecodedAssetBalance)>, AssetsStorageError> {
+) -> Result<AssetBalancesResult, AssetsStorageError> {
     use futures::future::join_all;
 
     let account_bytes: [u8; 32] = *account.as_ref();
 
-    // Create futures for all asset balance queries
+    // Query each asset in parallel, mapping the raw subxt result into a
+    // backend-independent `AssetBalanceOutcome`. Keeping the per-asset decision out
+    // of the async closure lets `collect_asset_balances` stay pure and unit-tested.
     let futures: Vec<_> = asset_ids
         .iter()
         .map(|&asset_id| {
             let storage_addr = subxt::dynamic::storage::<_, ()>("Assets", "Account");
             async move {
-                let result = client_at_block
+                // `try_fetch` returns `Ok(None)` when the account holds none of this
+                // asset (a legitimate absence) and `Err` only for a genuine fetch
+                // failure. The old `fetch`-based code could not tell these apart: an
+                // account that does not hold an asset surfaces as
+                // `StorageError::NoValueFound`, the same `Err` arm as a transient RPC
+                // failure, so real failures were dropped exactly like not-held assets
+                // (issue #342).
+                let outcome = match client_at_block
                     .storage()
-                    .fetch(storage_addr, (asset_id, account_bytes))
-                    .await;
-
-                (asset_id, result)
+                    .try_fetch(storage_addr, (asset_id, account_bytes))
+                    .await
+                {
+                    Ok(Some(value)) => match decode_asset_balance(&value.into_bytes()) {
+                        Ok(Some(decoded)) => AssetBalanceOutcome::Decoded(decoded),
+                        // `decode_asset_balance` never returns `Ok(None)`, but treat it
+                        // defensively as an absence rather than a fabricated error.
+                        Ok(None) => AssetBalanceOutcome::Absent,
+                        // Storage that is present but undecodable is a real error, not a
+                        // zero balance — surface it.
+                        Err(e) => {
+                            tracing::warn!(
+                                "Failed to decode asset balance for asset {asset_id}: {e}"
+                            );
+                            AssetBalanceOutcome::Failed(e.to_string())
+                        }
+                    },
+                    Ok(None) => AssetBalanceOutcome::Absent,
+                    Err(e) => {
+                        tracing::warn!("Failed to fetch asset balance for asset {asset_id}: {e:?}");
+                        AssetBalanceOutcome::Failed(e.to_string())
+                    }
+                };
+                (asset_id, outcome)
             }
         })
         .collect();
 
-    // Execute all queries in parallel
-    let results = join_all(futures).await;
-
-    // Process results
-    let mut balances = Vec::new();
-    for (asset_id, result) in results {
-        match result {
-            Ok(value) => {
-                let raw_bytes = value.into_bytes();
-                if let Ok(Some(decoded)) = decode_asset_balance(&raw_bytes) {
-                    balances.push((asset_id, decoded));
-                } else if show_empty {
-                    balances.push((
-                        asset_id,
-                        DecodedAssetBalance {
-                            balance: "0".to_string(),
-                            is_frozen: false,
-                            is_sufficient: false,
-                        },
-                    ));
-                }
-            }
-            Err(e) if show_empty => {
-                tracing::debug!(
-                    "Failed to fetch asset balance for asset (show_empty) {asset_id}: {e:?}"
-                );
-                balances.push((
-                    asset_id,
-                    DecodedAssetBalance {
-                        balance: "0".to_string(),
-                        is_frozen: false,
-                        is_sufficient: false,
-                    },
-                ));
-            }
-            Err(e) => {
-                tracing::debug!("Failed to fetch asset balance for asset {asset_id}: {e:?}");
-            }
-        }
-    }
-
-    Ok(balances)
+    let outcomes = join_all(futures).await;
+    Ok(collect_asset_balances(outcomes, show_empty))
 }
 
 /// Fetch asset approval from Assets::Approvals storage.
@@ -425,5 +491,65 @@ mod tests {
         assert!(!ExistenceReason::Consumer.is_sufficient());
         assert!(ExistenceReason::Sufficient.is_sufficient());
         assert!(!ExistenceReason::DepositRefunded.is_sufficient());
+    }
+
+    use super::{
+        AssetBalanceFetchError, AssetBalanceOutcome, DecodedAssetBalance, collect_asset_balances,
+    };
+
+    fn bal(amount: &str) -> DecodedAssetBalance {
+        DecodedAssetBalance {
+            balance: amount.to_string(),
+            is_frozen: false,
+            is_sufficient: false,
+        }
+    }
+
+    #[test]
+    fn collect_decoded_outcomes_go_to_balances() {
+        let out = vec![(1u32, AssetBalanceOutcome::Decoded(bal("100")))];
+        let result = collect_asset_balances(out, false);
+        assert_eq!(result.balances, vec![(1u32, bal("100"))]);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn collect_absent_is_omitted_when_show_empty_false() {
+        let out = vec![(7u32, AssetBalanceOutcome::Absent)];
+        let result = collect_asset_balances(out, false);
+        assert!(result.balances.is_empty());
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn collect_absent_is_zero_stub_when_show_empty_true() {
+        let out = vec![(7u32, AssetBalanceOutcome::Absent)];
+        let result = collect_asset_balances(out, true);
+        assert_eq!(result.balances, vec![(7u32, bal("0"))]);
+        assert!(result.errors.is_empty());
+    }
+
+    #[test]
+    fn collect_failed_goes_to_errors_never_balances() {
+        let out = vec![(9u32, AssetBalanceOutcome::Failed("rpc boom".to_string()))];
+        let result = collect_asset_balances(out, false);
+        assert!(result.balances.is_empty());
+        assert_eq!(
+            result.errors,
+            vec![AssetBalanceFetchError {
+                asset_id: 9,
+                reason: "rpc boom".to_string()
+            }]
+        );
+    }
+
+    #[test]
+    fn collect_failed_is_not_zero_stubbed_even_with_show_empty() {
+        // Ghost-zero guard (issue #342): a failed fetch must never become a zero balance,
+        // even when the caller asked to include empty balances.
+        let out = vec![(9u32, AssetBalanceOutcome::Failed("rpc boom".to_string()))];
+        let result = collect_asset_balances(out, true);
+        assert!(result.balances.is_empty());
+        assert_eq!(result.errors.len(), 1);
     }
 }

--- a/crates/server/src/handlers/runtime_queries/assets.rs
+++ b/crates/server/src/handlers/runtime_queries/assets.rs
@@ -319,10 +319,19 @@ pub async fn get_asset_balance(
     decode_asset_balance(&raw_bytes)
 }
 
+/// Client-facing reason for a failed per-asset fetch. Deliberately generic: the
+/// detailed subxt/RPC error (which can embed the upstream node URL/host) is logged
+/// server-side and never reflected to API clients.
+const REASON_FETCH_FAILED: &str = "storage query for this asset failed";
+/// Client-facing reason for present-but-undecodable asset storage.
+const REASON_DECODE_FAILED: &str = "asset balance could not be decoded";
+
 /// Fetch asset balances for multiple assets for an account.
 ///
 /// When `show_empty` is false (default), only returns assets that have non-zero balances.
 /// When `show_empty` is true, returns all requested assets including those with zero balance.
+/// Assets whose per-asset query genuinely failed are returned in
+/// [`AssetBalancesResult::errors`] rather than silently dropped (issue #342).
 ///
 /// This function executes all asset queries **in parallel** for optimal performance.
 /// For 100 assets, this takes ~1 network roundtrip instead of 100 sequential roundtrips.
@@ -331,7 +340,7 @@ pub async fn get_asset_balances(
     account: &AccountId32,
     asset_ids: &[u32],
     show_empty: bool,
-) -> Result<AssetBalancesResult, AssetsStorageError> {
+) -> AssetBalancesResult {
     use futures::future::join_all;
 
     let account_bytes: [u8; 32] = *account.as_ref();
@@ -344,13 +353,12 @@ pub async fn get_asset_balances(
         .map(|&asset_id| {
             let storage_addr = subxt::dynamic::storage::<_, ()>("Assets", "Account");
             async move {
-                // `try_fetch` returns `Ok(None)` when the account holds none of this
-                // asset (a legitimate absence) and `Err` only for a genuine fetch
-                // failure. The old `fetch`-based code could not tell these apart: an
-                // account that does not hold an asset surfaces as
-                // `StorageError::NoValueFound`, the same `Err` arm as a transient RPC
-                // failure, so real failures were dropped exactly like not-held assets
-                // (issue #342).
+                // `try_fetch` surfaces a not-held asset as `Ok(None)` and reserves `Err`
+                // for genuine fetch failures. `fetch` is just `try_fetch` with the final
+                // `None` mapped to `Err(NoValueFound)`, so the old `fetch`-based code
+                // collapsed "account holds none" into the same `Err` arm as a transient
+                // RPC failure and dropped both alike (issue #342). Both apply the entry
+                // default; `Assets::Account` has none, so absence is `Ok(None)`.
                 let outcome = match client_at_block
                     .storage()
                     .try_fetch(storage_addr, (asset_id, account_bytes))
@@ -361,19 +369,24 @@ pub async fn get_asset_balances(
                         // `decode_asset_balance` never returns `Ok(None)`, but treat it
                         // defensively as an absence rather than a fabricated error.
                         Ok(None) => AssetBalanceOutcome::Absent,
-                        // Storage that is present but undecodable is a real error, not a
-                        // zero balance — surface it.
+                        // Present but undecodable storage is a real error, not a zero
+                        // balance. Detail stays in the server log; the client gets a
+                        // generic reason so internals are not reflected in the response.
                         Err(e) => {
-                            tracing::warn!(
+                            tracing::debug!(
                                 "Failed to decode asset balance for asset {asset_id}: {e}"
                             );
-                            AssetBalanceOutcome::Failed(e.to_string())
+                            AssetBalanceOutcome::Failed(REASON_DECODE_FAILED.to_string())
                         }
                     },
                     Ok(None) => AssetBalanceOutcome::Absent,
+                    // The detailed error (which can include the upstream node URL/host)
+                    // stays in the server log; the client gets a generic reason only.
                     Err(e) => {
-                        tracing::warn!("Failed to fetch asset balance for asset {asset_id}: {e:?}");
-                        AssetBalanceOutcome::Failed(e.to_string())
+                        tracing::debug!(
+                            "Failed to fetch asset balance for asset {asset_id}: {e:?}"
+                        );
+                        AssetBalanceOutcome::Failed(REASON_FETCH_FAILED.to_string())
                     }
                 };
                 (asset_id, outcome)
@@ -382,7 +395,21 @@ pub async fn get_asset_balances(
         .collect();
 
     let outcomes = join_all(futures).await;
-    Ok(collect_asset_balances(outcomes, show_empty))
+    let result = collect_asset_balances(outcomes, show_empty);
+
+    // One aggregate warning per request keeps the partial result visible to operators
+    // at the default log level, without emitting one warn line per failed asset — on the
+    // "query all assets" path during a node outage that would be thousands of synchronous
+    // log writes. Per-asset detail is available at `debug` above.
+    if !result.errors.is_empty() {
+        tracing::warn!(
+            "asset-balances: {} of {} per-asset queries failed for {account}; returning a partial result",
+            result.errors.len(),
+            asset_ids.len(),
+        );
+    }
+
+    result
 }
 
 /// Fetch asset approval from Assets::Approvals storage.

--- a/crates/server/src/handlers/runtime_queries/assets.rs
+++ b/crates/server/src/handlers/runtime_queries/assets.rs
@@ -98,7 +98,10 @@ pub struct DecodedAssetBalance {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssetBalanceFetchError {
     pub asset_id: u32,
-    pub reason: String,
+    /// Generic, client-safe reason (one of the `REASON_*` constants). Borrowed because
+    /// the reasons are compile-time constants — avoids a heap allocation per failed
+    /// asset on the "query all assets" outage path.
+    pub reason: &'static str,
 }
 
 /// Result of fetching balances for multiple assets.
@@ -122,7 +125,8 @@ enum AssetBalanceOutcome {
     /// Account holds no entry for this asset — a legitimate absence, not an error.
     Absent,
     /// Fetch or decode failed — a real error we must surface, never a zero balance.
-    Failed(String),
+    /// Carries a generic, client-safe reason (a `REASON_*` constant).
+    Failed(&'static str),
 }
 
 /// Build a zero-balance stub for assets the account does not hold (used when the
@@ -147,7 +151,11 @@ fn collect_asset_balances(
     outcomes: Vec<(u32, AssetBalanceOutcome)>,
     show_empty: bool,
 ) -> AssetBalancesResult {
-    let mut result = AssetBalancesResult::default();
+    let mut result = AssetBalancesResult {
+        // Most outcomes are decoded/zero-stub balances; failures are the exception.
+        balances: Vec::with_capacity(outcomes.len()),
+        errors: Vec::new(),
+    };
     for (asset_id, outcome) in outcomes {
         match outcome {
             AssetBalanceOutcome::Decoded(decoded) => result.balances.push((asset_id, decoded)),
@@ -376,7 +384,7 @@ pub async fn get_asset_balances(
                             tracing::debug!(
                                 "Failed to decode asset balance for asset {asset_id}: {e}"
                             );
-                            AssetBalanceOutcome::Failed(REASON_DECODE_FAILED.to_string())
+                            AssetBalanceOutcome::Failed(REASON_DECODE_FAILED)
                         }
                     },
                     Ok(None) => AssetBalanceOutcome::Absent,
@@ -386,7 +394,7 @@ pub async fn get_asset_balances(
                         tracing::debug!(
                             "Failed to fetch asset balance for asset {asset_id}: {e:?}"
                         );
-                        AssetBalanceOutcome::Failed(REASON_FETCH_FAILED.to_string())
+                        AssetBalanceOutcome::Failed(REASON_FETCH_FAILED)
                     }
                 };
                 (asset_id, outcome)
@@ -558,14 +566,14 @@ mod tests {
 
     #[test]
     fn collect_failed_goes_to_errors_never_balances() {
-        let out = vec![(9u32, AssetBalanceOutcome::Failed("rpc boom".to_string()))];
+        let out = vec![(9u32, AssetBalanceOutcome::Failed("rpc boom"))];
         let result = collect_asset_balances(out, false);
         assert!(result.balances.is_empty());
         assert_eq!(
             result.errors,
             vec![AssetBalanceFetchError {
                 asset_id: 9,
-                reason: "rpc boom".to_string()
+                reason: "rpc boom"
             }]
         );
     }
@@ -574,7 +582,7 @@ mod tests {
     fn collect_failed_is_not_zero_stubbed_even_with_show_empty() {
         // Ghost-zero guard (issue #342): a failed fetch must never become a zero balance,
         // even when the caller asked to include empty balances.
-        let out = vec![(9u32, AssetBalanceOutcome::Failed("rpc boom".to_string()))];
+        let out = vec![(9u32, AssetBalanceOutcome::Failed("rpc boom"))];
         let result = collect_asset_balances(out, true);
         assert!(result.balances.is_empty());
         assert_eq!(result.errors.len(), 1);


### PR DESCRIPTION
Closes #342

### Description

The `/accounts/{accountId}/asset-balances` endpoint used to silently drop an asset when its per-asset query failed: the response was still `200 OK`, just missing that `assetId`. Clients that read "assetId not in the list" as "balance = 0" got ghost-zero balances whenever the node had a transient RPC failure.

This change tells apart two cases that were previously merged:
- the account simply holds none of the asset (correctly omitted)
- the per-asset query actually failed (now reported, not dropped)

Failed assets are returned in new optional response fields. The default response stays `200` and gains no fields when nothing failed, so existing clients are unaffected.

What changed for API clients:
- `partial` (bool) - present and `true` only when some assets could not be fetched
- `errors` (array of `{ assetId, reason }`) - which assets failed. `reason` is a generic message (the detailed error is logged server-side, not exposed); the list is capped, so `partial` is the authoritative "incomplete" signal
- `strict` (query param, optional) - when `true`, return `503` instead of a partial `200` if any asset fails
- the endpoint now returns `503` (retryable) instead of `400` if it cannot list the chain's assets due to a transient node failure

### Changes by file

- `crates/server/src/handlers/runtime_queries/assets.rs` - Switched the per-asset lookup from `fetch` to `try_fetch` so "not held" (`Ok(None)`) is distinct from a real failure (`Err`). Failures are collected instead of dropped, with a generic reason (detail logged at debug) and one aggregate warning per request. Returns balances plus a list of failed assets.
- `crates/server/src/handlers/accounts/utils/assets.rs` - Passes both the balances and the list of failures up to the handler.
- `crates/server/src/handlers/accounts/types.rs` - Adds the `partial` and `errors` response fields, the `strict` query param, and `503` error types (strict mode and failed asset enumeration).
- `crates/server/src/handlers/accounts/get_asset_balances.rs` - Sets `partial`/`errors` on the response, caps the `errors` list, returns `503` in strict mode (and when asset enumeration fails), and updates the OpenAPI docs (new fields/param + a note that a missing assetId is not a zero balance).

### Tests

- Unit tests for the per-asset classification (decoded, absent, failed) including the guard that a failed query is never reported as a zero balance.
- Unit tests for the response fields (`partial`/`errors` omitted when complete, present when partial) and the `strict` query param.

### Verification
- `cargo build --release --package polkadot-rest-api`
- `cargo test --package polkadot-rest-api --lib`
- `cargo check --workspace --all-targets`
- `cargo clippy --package polkadot-rest-api`
- `cargo +nightly fmt --check`
