### PR TITLE
ci: bump nightly toolchain to 2026-06-16 and fix resulting lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-09-14
+          toolchain: nightly-2026-06-16
           components: rustfmt
 
       - name: Check formatting
@@ -34,7 +34,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-09-14
+          toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -72,7 +72,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-09-14
+          toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -112,7 +112,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-09-14
+          toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
         uses: actions/cache@v4
@@ -303,7 +303,7 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-09-14
+          toolchain: nightly-2026-06-16
           components: clippy
 
       - name: Cache cargo registry

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,19 @@
 
 Steps to prepare a new release of `polkadot-rest-api`.
 
+> **Before you start — check the CI toolchain pin.** CI pins a specific Rust
+> nightly in `.github/workflows/ci.yml` (the `toolchain: nightly-YYYY-MM-DD`
+> lines, currently repeated across all jobs). Check whether it's stale and bump
+> it if needed — but do this in a **separate PR ahead of the release**, never in
+> the release PR itself: a newer nightly can surface new clippy lints that need
+> fixing, and that churn should not block the release. Verify a bump locally with
+> the same checks CI runs:
+>
+> ```bash
+> cargo +nightly-YYYY-MM-DD fmt --all -- --check
+> cargo +nightly-YYYY-MM-DD clippy --workspace --all-features -- -D warnings
+> ```
+
 ## 1. Bump workspace version
 
 Update the `version` field in the root `Cargo.toml`:

--- a/crates/integration_tests/tests/accounts/mod.rs
+++ b/crates/integration_tests/tests/accounts/mod.rs
@@ -200,14 +200,13 @@ impl EndpointType {
 
 /// Check if relay chain is not available and test should be skipped
 pub fn should_skip_rc_test(status: u16, json: &serde_json::Value) -> bool {
-    if status == 400 {
-        if let Some(response_obj) = json.as_object() {
-            if let Some(error) = response_obj.get("error") {
-                let error_str = error.as_str().unwrap_or("");
-                if error_str.contains("Relay chain not available") {
-                    return true;
-                }
-            }
+    if status == 400
+        && let Some(response_obj) = json.as_object()
+        && let Some(error) = response_obj.get("error")
+    {
+        let error_str = error.as_str().unwrap_or("");
+        if error_str.contains("Relay chain not available") {
+            return true;
         }
     }
     false
@@ -215,16 +214,15 @@ pub fn should_skip_rc_test(status: u16, json: &serde_json::Value) -> bool {
 
 /// Check if staking pallet is not available and test should be skipped
 pub fn should_skip_staking_test(status: u16, json: &serde_json::Value) -> bool {
-    if status == 400 || status == 500 {
-        if let Some(response_obj) = json.as_object() {
-            if let Some(error) = response_obj.get("error") {
-                let error_str = error.as_str().unwrap_or("");
-                if error_str.contains("Staking pallet not available")
-                    || error_str.contains("not available on this chain")
-                {
-                    return true;
-                }
-            }
+    if (status == 400 || status == 500)
+        && let Some(response_obj) = json.as_object()
+        && let Some(error) = response_obj.get("error")
+    {
+        let error_str = error.as_str().unwrap_or("");
+        if error_str.contains("Staking pallet not available")
+            || error_str.contains("not available on this chain")
+        {
+            return true;
         }
     }
     false

--- a/crates/integration_tests/tests/accounts/staking_info.rs
+++ b/crates/integration_tests/tests/accounts/staking_info.rs
@@ -87,23 +87,23 @@ fn should_skip_test(
     }
 
     // For 500 errors, also check the error message for staking-related issues
-    if status == 500 {
-        if let Some(error) = json.as_object().and_then(|o| o.get("error")) {
-            let error_str = error.as_str().unwrap_or("");
-            // Skip if the error indicates staking functionality is not available
-            if error_str.contains("staking")
-                || error_str.contains("Staking")
-                || error_str.contains("pallet")
-                || error_str.contains("not found")
-            {
-                println!(
-                    "  {} Staking functionality not available (500 error, skipping {} test): {}",
-                    "!".yellow(),
-                    endpoint_type.name(),
-                    error_str
-                );
-                return Ok(true);
-            }
+    if status == 500
+        && let Some(error) = json.as_object().and_then(|o| o.get("error"))
+    {
+        let error_str = error.as_str().unwrap_or("");
+        // Skip if the error indicates staking functionality is not available
+        if error_str.contains("staking")
+            || error_str.contains("Staking")
+            || error_str.contains("pallet")
+            || error_str.contains("not found")
+        {
+            println!(
+                "  {} Staking functionality not available (500 error, skipping {} test): {}",
+                "!".yellow(),
+                endpoint_type.name(),
+                error_str
+            );
+            return Ok(true);
         }
     }
 
@@ -332,15 +332,15 @@ async fn run_non_stash_account_test(endpoint_type: EndpointType) -> Result<()> {
 
     // Either success (it's a stash) or 400 (not a stash or staking unavailable)
     if status.as_u16() == 400 || status.as_u16() == 500 {
-        if let Some(response_obj) = json.as_object() {
-            if let Some(error) = response_obj.get("error") {
-                let error_msg = error.as_str().unwrap_or("Unknown error");
-                println!(
-                    "  {} Account is not a stash or staking unavailable: {}",
-                    "+".green(),
-                    error_msg
-                );
-            }
+        if let Some(response_obj) = json.as_object()
+            && let Some(error) = response_obj.get("error")
+        {
+            let error_msg = error.as_str().unwrap_or("Unknown error");
+            println!(
+                "  {} Account is not a stash or staking unavailable: {}",
+                "+".green(),
+                error_msg
+            );
         }
     } else {
         assert!(

--- a/crates/integration_tests/tests/accounts/staking_payouts.rs
+++ b/crates/integration_tests/tests/accounts/staking_payouts.rs
@@ -96,24 +96,24 @@ fn should_skip_test(
     }
 
     // For 500 errors, also check the error message for staking-related issues
-    if status == 500 {
-        if let Some(error) = json.as_object().and_then(|o| o.get("error")) {
-            let error_str = error.as_str().unwrap_or("");
-            // Skip if the error indicates staking functionality is not available
-            if error_str.contains("staking")
-                || error_str.contains("Staking")
-                || error_str.contains("pallet")
-                || error_str.contains("not found")
-                || error_str.contains("era")
-            {
-                println!(
-                    "  {} Staking functionality not available (500 error, skipping {} test): {}",
-                    "!".yellow(),
-                    endpoint_type.name(),
-                    error_str
-                );
-                return Ok(true);
-            }
+    if status == 500
+        && let Some(error) = json.as_object().and_then(|o| o.get("error"))
+    {
+        let error_str = error.as_str().unwrap_or("");
+        // Skip if the error indicates staking functionality is not available
+        if error_str.contains("staking")
+            || error_str.contains("Staking")
+            || error_str.contains("pallet")
+            || error_str.contains("not found")
+            || error_str.contains("era")
+        {
+            println!(
+                "  {} Staking functionality not available (500 error, skipping {} test): {}",
+                "!".yellow(),
+                endpoint_type.name(),
+                error_str
+            );
+            return Ok(true);
         }
     }
 

--- a/crates/integration_tests/tests/coretime.rs
+++ b/crates/integration_tests/tests/coretime.rs
@@ -36,12 +36,11 @@ async fn setup_client() -> Result<TestClient> {
 
 /// Check if the connected chain is a coretime chain (has Broker pallet)
 async fn is_coretime_chain(client: &TestClient) -> bool {
-    if let Ok((status, json)) = client.get_json("/v1/capabilities").await {
-        if status.is_success() {
-            if let Some(pallets) = json["pallets"].as_array() {
-                return pallets.iter().any(|p| p.as_str() == Some("Broker"));
-            }
-        }
+    if let Ok((status, json)) = client.get_json("/v1/capabilities").await
+        && status.is_success()
+        && let Some(pallets) = json["pallets"].as_array()
+    {
+        return pallets.iter().any(|p| p.as_str() == Some("Broker"));
     }
     false
 }
@@ -947,48 +946,48 @@ async fn test_coretime_renewals_item_structure() -> Result<()> {
     assert!(renewal["task"].is_string(), "'task' should be a string");
 
     // Optional fields (if present should have correct types)
-    if let Some(completion) = renewal.get("completion") {
-        if !completion.is_null() {
-            assert!(
-                completion.is_string(),
-                "'completion' should be a string when present"
-            );
-            let completion_str = completion.as_str().unwrap();
-            assert!(
-                completion_str == "Complete" || completion_str == "Partial",
-                "'completion' should be 'Complete' or 'Partial', got: {}",
-                completion_str
-            );
-        }
+    if let Some(completion) = renewal.get("completion")
+        && !completion.is_null()
+    {
+        assert!(
+            completion.is_string(),
+            "'completion' should be a string when present"
+        );
+        let completion_str = completion.as_str().unwrap();
+        assert!(
+            completion_str == "Complete" || completion_str == "Partial",
+            "'completion' should be 'Complete' or 'Partial', got: {}",
+            completion_str
+        );
     }
 
-    if let Some(mask) = renewal.get("mask") {
-        if !mask.is_null() {
-            assert!(mask.is_string(), "'mask' should be a string when present");
-            let mask_str = mask.as_str().unwrap();
-            assert!(
-                mask_str.starts_with("0x"),
-                "'mask' should be a hex string starting with 0x"
-            );
-            // CoreMask is 80 bits = 10 bytes = 20 hex chars + "0x" prefix
-            assert_eq!(
-                mask_str.len(),
-                22,
-                "'mask' should be 22 characters (0x + 20 hex digits for 10 bytes)"
-            );
-        }
+    if let Some(mask) = renewal.get("mask")
+        && !mask.is_null()
+    {
+        assert!(mask.is_string(), "'mask' should be a string when present");
+        let mask_str = mask.as_str().unwrap();
+        assert!(
+            mask_str.starts_with("0x"),
+            "'mask' should be a hex string starting with 0x"
+        );
+        // CoreMask is 80 bits = 10 bytes = 20 hex chars + "0x" prefix
+        assert_eq!(
+            mask_str.len(),
+            22,
+            "'mask' should be 22 characters (0x + 20 hex digits for 10 bytes)"
+        );
     }
 
-    if let Some(price) = renewal.get("price") {
-        if !price.is_null() {
-            assert!(price.is_string(), "'price' should be a string when present");
-            let price_str = price.as_str().unwrap();
-            assert!(
-                price_str.parse::<u128>().is_ok(),
-                "'price' should be a numeric string, got: {}",
-                price_str
-            );
-        }
+    if let Some(price) = renewal.get("price")
+        && !price.is_null()
+    {
+        assert!(price.is_string(), "'price' should be a string when present");
+        let price_str = price.as_str().unwrap();
+        assert!(
+            price_str.parse::<u128>().is_ok(),
+            "'price' should be a numeric string, got: {}",
+            price_str
+        );
     }
 
     // Validate task is empty, "Pool", "Idle", or a numeric string (task ID)
@@ -1414,36 +1413,36 @@ async fn test_coretime_regions_item_structure() -> Result<()> {
 
     // Optional fields: end, owner, paid
     // If present, check their types
-    if let Some(end) = region.get("end") {
-        if !end.is_null() {
-            assert!(end.is_number(), "'end' should be a number when present");
-        }
+    if let Some(end) = region.get("end")
+        && !end.is_null()
+    {
+        assert!(end.is_number(), "'end' should be a number when present");
     }
 
-    if let Some(owner) = region.get("owner") {
-        if !owner.is_null() {
-            assert!(owner.is_string(), "'owner' should be a string when present");
-            let owner_str = owner.as_str().unwrap();
-            // Owner is an SS58-encoded address (base58 string, typically 47-48 chars)
-            // This matches substrate-api-sidecar behavior which uses .toString() on AccountId
-            assert!(
-                !owner_str.is_empty() && owner_str.chars().all(|c| c.is_alphanumeric()),
-                "'owner' should be a valid SS58 address string, got: {}",
-                owner_str
-            );
-        }
+    if let Some(owner) = region.get("owner")
+        && !owner.is_null()
+    {
+        assert!(owner.is_string(), "'owner' should be a string when present");
+        let owner_str = owner.as_str().unwrap();
+        // Owner is an SS58-encoded address (base58 string, typically 47-48 chars)
+        // This matches substrate-api-sidecar behavior which uses .toString() on AccountId
+        assert!(
+            !owner_str.is_empty() && owner_str.chars().all(|c| c.is_alphanumeric()),
+            "'owner' should be a valid SS58 address string, got: {}",
+            owner_str
+        );
     }
 
-    if let Some(paid) = region.get("paid") {
-        if !paid.is_null() {
-            assert!(paid.is_string(), "'paid' should be a string when present");
-            // paid should be a numeric string
-            let paid_str = paid.as_str().unwrap();
-            assert!(
-                paid_str.parse::<u128>().is_ok(),
-                "'paid' should be a numeric string"
-            );
-        }
+    if let Some(paid) = region.get("paid")
+        && !paid.is_null()
+    {
+        assert!(paid.is_string(), "'paid' should be a string when present");
+        // paid should be a numeric string
+        let paid_str = paid.as_str().unwrap();
+        assert!(
+            paid_str.parse::<u128>().is_ok(),
+            "'paid' should be a numeric string"
+        );
     }
 
     println!(
@@ -1801,40 +1800,40 @@ async fn test_coretime_info_configuration() -> Result<()> {
     assert!(status.is_success());
 
     // Configuration may be present if broker is configured
-    if let Some(config) = json.get("configuration") {
-        if !config.is_null() {
-            assert!(
-                config.get("regionLength").is_some(),
-                "Configuration should have 'regionLength'"
-            );
-            assert!(
-                config.get("interludeLength").is_some(),
-                "Configuration should have 'interludeLength'"
-            );
-            assert!(
-                config.get("leadinLength").is_some(),
-                "Configuration should have 'leadinLength'"
-            );
-            assert!(
-                config.get("relayBlocksPerTimeslice").is_some(),
-                "Configuration should have 'relayBlocksPerTimeslice'"
-            );
+    if let Some(config) = json.get("configuration")
+        && !config.is_null()
+    {
+        assert!(
+            config.get("regionLength").is_some(),
+            "Configuration should have 'regionLength'"
+        );
+        assert!(
+            config.get("interludeLength").is_some(),
+            "Configuration should have 'interludeLength'"
+        );
+        assert!(
+            config.get("leadinLength").is_some(),
+            "Configuration should have 'leadinLength'"
+        );
+        assert!(
+            config.get("relayBlocksPerTimeslice").is_some(),
+            "Configuration should have 'relayBlocksPerTimeslice'"
+        );
 
-            // Verify values are numbers (u32 fields)
-            assert!(
-                config["regionLength"].is_number(),
-                "'regionLength' should be a number"
-            );
-            assert!(
-                config["relayBlocksPerTimeslice"].is_number(),
-                "'relayBlocksPerTimeslice' should be a number"
-            );
+        // Verify values are numbers (u32 fields)
+        assert!(
+            config["regionLength"].is_number(),
+            "'regionLength' should be a number"
+        );
+        assert!(
+            config["relayBlocksPerTimeslice"].is_number(),
+            "'relayBlocksPerTimeslice' should be a number"
+        );
 
-            println!(
-                "ok: Configuration found - regionLength: {}, timeslicePeriod: {}",
-                config["regionLength"], config["relayBlocksPerTimeslice"]
-            );
-        }
+        println!(
+            "ok: Configuration found - regionLength: {}, timeslicePeriod: {}",
+            config["regionLength"], config["relayBlocksPerTimeslice"]
+        );
     }
 
     println!("ok: Coretime info configuration test passed");
@@ -1856,45 +1855,45 @@ async fn test_coretime_info_cores() -> Result<()> {
     assert!(status.is_success());
 
     // Cores section may be present if a sale is active
-    if let Some(cores) = json.get("cores") {
-        if !cores.is_null() {
-            assert!(
-                cores.get("available").is_some(),
-                "Cores should have 'available'"
-            );
-            assert!(cores.get("sold").is_some(), "Cores should have 'sold'");
-            assert!(cores.get("total").is_some(), "Cores should have 'total'");
-            assert!(
-                cores.get("currentCorePrice").is_some(),
-                "Cores should have 'currentCorePrice'"
-            );
+    if let Some(cores) = json.get("cores")
+        && !cores.is_null()
+    {
+        assert!(
+            cores.get("available").is_some(),
+            "Cores should have 'available'"
+        );
+        assert!(cores.get("sold").is_some(), "Cores should have 'sold'");
+        assert!(cores.get("total").is_some(), "Cores should have 'total'");
+        assert!(
+            cores.get("currentCorePrice").is_some(),
+            "Cores should have 'currentCorePrice'"
+        );
 
-            // Verify types - u32 fields are numbers, u128 (Balance) fields are strings
-            assert!(
-                cores["available"].is_number(),
-                "'available' should be a number"
-            );
-            assert!(cores["sold"].is_number(), "'sold' should be a number");
-            assert!(cores["total"].is_number(), "'total' should be a number");
-            assert!(
-                cores["currentCorePrice"].is_string(),
-                "'currentCorePrice' should be a string (u128 Balance)"
-            );
+        // Verify types - u32 fields are numbers, u128 (Balance) fields are strings
+        assert!(
+            cores["available"].is_number(),
+            "'available' should be a number"
+        );
+        assert!(cores["sold"].is_number(), "'sold' should be a number");
+        assert!(cores["total"].is_number(), "'total' should be a number");
+        assert!(
+            cores["currentCorePrice"].is_string(),
+            "'currentCorePrice' should be a string (u128 Balance)"
+        );
 
-            // Verify logical constraints
-            let available = cores["available"].as_u64().unwrap();
-            let sold = cores["sold"].as_u64().unwrap();
-            let total = cores["total"].as_u64().unwrap();
-            assert!(
-                available + sold <= total,
-                "available + sold should be <= total"
-            );
+        // Verify logical constraints
+        let available = cores["available"].as_u64().unwrap();
+        let sold = cores["sold"].as_u64().unwrap();
+        let total = cores["total"].as_u64().unwrap();
+        assert!(
+            available + sold <= total,
+            "available + sold should be <= total"
+        );
 
-            println!(
-                "ok: Cores found - available: {}, sold: {}, total: {}",
-                available, sold, total
-            );
-        }
+        println!(
+            "ok: Cores found - available: {}, sold: {}, total: {}",
+            available, sold, total
+        );
     }
 
     println!("ok: Coretime info cores test passed");
@@ -1916,43 +1915,43 @@ async fn test_coretime_info_phase() -> Result<()> {
     assert!(status.is_success());
 
     // Phase section may be present if broker is configured and sale is active
-    if let Some(phase) = json.get("phase") {
-        if !phase.is_null() {
+    if let Some(phase) = json.get("phase")
+        && !phase.is_null()
+    {
+        assert!(
+            phase.get("currentPhase").is_some(),
+            "Phase should have 'currentPhase'"
+        );
+        assert!(phase.get("config").is_some(), "Phase should have 'config'");
+
+        let current_phase = phase["currentPhase"].as_str().unwrap();
+        assert!(
+            ["renewals", "priceDiscovery", "fixedPrice"].contains(&current_phase),
+            "'currentPhase' should be one of: renewals, priceDiscovery, fixedPrice, got: {}",
+            current_phase
+        );
+
+        // Verify config is an array
+        assert!(phase["config"].is_array(), "'config' should be an array");
+
+        let config_array = phase["config"].as_array().unwrap();
+        if !config_array.is_empty() {
+            let first_phase = &config_array[0];
             assert!(
-                phase.get("currentPhase").is_some(),
-                "Phase should have 'currentPhase'"
+                first_phase.get("phaseName").is_some(),
+                "Phase config should have 'phaseName'"
             );
-            assert!(phase.get("config").is_some(), "Phase should have 'config'");
-
-            let current_phase = phase["currentPhase"].as_str().unwrap();
             assert!(
-                ["renewals", "priceDiscovery", "fixedPrice"].contains(&current_phase),
-                "'currentPhase' should be one of: renewals, priceDiscovery, fixedPrice, got: {}",
-                current_phase
+                first_phase.get("lastRelayBlock").is_some(),
+                "Phase config should have 'lastRelayBlock'"
             );
-
-            // Verify config is an array
-            assert!(phase["config"].is_array(), "'config' should be an array");
-
-            let config_array = phase["config"].as_array().unwrap();
-            if !config_array.is_empty() {
-                let first_phase = &config_array[0];
-                assert!(
-                    first_phase.get("phaseName").is_some(),
-                    "Phase config should have 'phaseName'"
-                );
-                assert!(
-                    first_phase.get("lastRelayBlock").is_some(),
-                    "Phase config should have 'lastRelayBlock'"
-                );
-                assert!(
-                    first_phase.get("lastTimeslice").is_some(),
-                    "Phase config should have 'lastTimeslice'"
-                );
-            }
-
-            println!("ok: Phase found - currentPhase: {}", current_phase);
+            assert!(
+                first_phase.get("lastTimeslice").is_some(),
+                "Phase config should have 'lastTimeslice'"
+            );
         }
+
+        println!("ok: Phase found - currentPhase: {}", current_phase);
     }
 
     println!("ok: Coretime info phase test passed");
@@ -2130,14 +2129,13 @@ async fn test_coretime_info_consistency() -> Result<()> {
 
 /// Check if the connected chain is a relay chain (has Coretime pallet but not Broker)
 async fn is_relay_chain(client: &TestClient) -> bool {
-    if let Ok((status, json)) = client.get_json("/v1/capabilities").await {
-        if status.is_success() {
-            if let Some(pallets) = json["pallets"].as_array() {
-                let has_coretime = pallets.iter().any(|p| p.as_str() == Some("Coretime"));
-                let has_broker = pallets.iter().any(|p| p.as_str() == Some("Broker"));
-                return has_coretime && !has_broker;
-            }
-        }
+    if let Ok((status, json)) = client.get_json("/v1/capabilities").await
+        && status.is_success()
+        && let Some(pallets) = json["pallets"].as_array()
+    {
+        let has_coretime = pallets.iter().any(|p| p.as_str() == Some("Coretime"));
+        let has_broker = pallets.iter().any(|p| p.as_str() == Some("Broker"));
+        return has_coretime && !has_broker;
     }
     false
 }
@@ -2179,33 +2177,33 @@ async fn test_coretime_info_relay_chain_response() -> Result<()> {
 
     if has_relay_fields {
         // If brokerId is present, verify it's a number (u32)
-        if let Some(broker_id) = json.get("brokerId") {
-            if !broker_id.is_null() {
-                assert!(
-                    broker_id.is_number(),
-                    "'brokerId' should be a number when present"
-                );
-            }
+        if let Some(broker_id) = json.get("brokerId")
+            && !broker_id.is_null()
+        {
+            assert!(
+                broker_id.is_number(),
+                "'brokerId' should be a number when present"
+            );
         }
 
         // If storageVersion is present, verify it's a number (u16)
-        if let Some(version) = json.get("storageVersion") {
-            if !version.is_null() {
-                assert!(
-                    version.is_number(),
-                    "'storageVersion' should be a number when present"
-                );
-            }
+        if let Some(version) = json.get("storageVersion")
+            && !version.is_null()
+        {
+            assert!(
+                version.is_number(),
+                "'storageVersion' should be a number when present"
+            );
         }
 
         // If maxHistoricalRevenue is present, verify it's a number (u32)
-        if let Some(revenue) = json.get("maxHistoricalRevenue") {
-            if !revenue.is_null() {
-                assert!(
-                    revenue.is_number(),
-                    "'maxHistoricalRevenue' should be a number when present"
-                );
-            }
+        if let Some(revenue) = json.get("maxHistoricalRevenue")
+            && !revenue.is_null()
+        {
+            assert!(
+                revenue.is_number(),
+                "'maxHistoricalRevenue' should be a number when present"
+            );
         }
     }
 
@@ -2760,7 +2758,7 @@ async fn test_coretime_overview_data_aggregation() -> Result<()> {
 
     // Basic sanity checks
     assert!(
-        cores.len() > 0 || (leases.is_empty() && reservations.is_empty()),
+        !cores.is_empty() || (leases.is_empty() && reservations.is_empty()),
         "If there are leases or reservations, there should be cores in overview"
     );
 
@@ -2824,26 +2822,26 @@ async fn test_coretime_overview_workplan_structure() -> Result<()> {
         );
 
         // If info array is not empty, check its structure
-        if let Some(info_array) = entry["info"].as_array() {
-            if !info_array.is_empty() {
-                let info_item = &info_array[0];
-                assert!(
-                    info_item.get("isPool").is_some(),
-                    "Workplan info should have 'isPool' field"
-                );
-                assert!(
-                    info_item.get("isTask").is_some(),
-                    "Workplan info should have 'isTask' field"
-                );
-                assert!(
-                    info_item.get("mask").is_some(),
-                    "Workplan info should have 'mask' field"
-                );
-                assert!(
-                    info_item.get("task").is_some(),
-                    "Workplan info should have 'task' field"
-                );
-            }
+        if let Some(info_array) = entry["info"].as_array()
+            && !info_array.is_empty()
+        {
+            let info_item = &info_array[0];
+            assert!(
+                info_item.get("isPool").is_some(),
+                "Workplan info should have 'isPool' field"
+            );
+            assert!(
+                info_item.get("isTask").is_some(),
+                "Workplan info should have 'isTask' field"
+            );
+            assert!(
+                info_item.get("mask").is_some(),
+                "Workplan info should have 'mask' field"
+            );
+            assert!(
+                info_item.get("task").is_some(),
+                "Workplan info should have 'task' field"
+            );
         }
 
         println!(

--- a/crates/server/src/extractors.rs
+++ b/crates/server/src/extractors.rs
@@ -126,7 +126,9 @@ mod tests {
         pub at: Option<String>,
     }
 
-    async fn test_handler(JsonQuery(_params): JsonQuery<TestParams>) -> &'static str {
+    async fn test_handler(JsonQuery(params): JsonQuery<TestParams>) -> &'static str {
+        // read the parsed fields so they aren't flagged as dead code
+        let _ = (&params.event_docs, &params.at);
         "ok"
     }
 

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -337,7 +337,7 @@ impl From<utils::ResolveClientAtBlockError> for AccountsError {
                 AccountsError::BlockResolveFailed(utils::BlockResolveError::NotFound(msg))
             }
             utils::ResolveClientAtBlockError::SubxtError(e) => {
-                AccountsError::ClientAtBlockFailed(Box::new(e))
+                AccountsError::ClientAtBlockFailed(e)
             }
         }
     }

--- a/crates/server/src/handlers/blocks/types.rs
+++ b/crates/server/src/handlers/blocks/types.rs
@@ -277,7 +277,7 @@ impl From<utils::ResolveClientAtBlockError> for GetBlockError {
                 GetBlockError::BlockResolveFailed(utils::BlockResolveError::NotFound(msg))
             }
             utils::ResolveClientAtBlockError::SubxtError(e) => {
-                GetBlockError::ClientAtBlockFailed(Box::new(e))
+                GetBlockError::ClientAtBlockFailed(e)
             }
         }
     }
@@ -391,7 +391,7 @@ pub enum GetBlockHeaderError {
     RelayChain(#[from] RelayChainError),
 
     #[error("Failed to get client at block: {0}")]
-    ClientAtBlockFailed(#[source] OnlineClientAtBlockError),
+    ClientAtBlockFailed(#[source] Box<OnlineClientAtBlockError>),
 }
 
 impl From<utils::AtBlockError> for GetBlockHeaderError {
@@ -400,7 +400,7 @@ impl From<utils::AtBlockError> for GetBlockHeaderError {
             utils::AtBlockError::BlockNotFound(msg) => {
                 GetBlockHeaderError::BlockResolveFailed(utils::BlockResolveError::NotFound(msg))
             }
-            utils::AtBlockError::Client(e) => GetBlockHeaderError::ClientAtBlockFailed(e),
+            utils::AtBlockError::Client(e) => GetBlockHeaderError::ClientAtBlockFailed(Box::new(e)),
         }
     }
 }

--- a/crates/server/src/handlers/coretime/common.rs
+++ b/crates/server/src/handlers/coretime/common.rs
@@ -140,7 +140,7 @@ pub enum CoretimeError {
     InvalidBlockHash,
 
     #[error("Failed to get client at block")]
-    ClientAtBlockFailed(#[source] subxt::error::OnlineClientAtBlockError),
+    ClientAtBlockFailed(#[source] Box<subxt::error::OnlineClientAtBlockError>),
 
     // ========================================================================
     // Chain Type Errors
@@ -207,7 +207,9 @@ impl From<crate::utils::AtBlockError> for CoretimeError {
             crate::utils::AtBlockError::BlockNotFound(msg) => {
                 CoretimeError::BlockResolveFailed(crate::utils::BlockResolveError::NotFound(msg))
             }
-            crate::utils::AtBlockError::Client(e) => CoretimeError::ClientAtBlockFailed(e),
+            crate::utils::AtBlockError::Client(e) => {
+                CoretimeError::ClientAtBlockFailed(Box::new(e))
+            }
         }
     }
 }

--- a/crates/server/src/handlers/coretime/leases.rs
+++ b/crates/server/src/handlers/coretime/leases.rs
@@ -287,7 +287,7 @@ mod tests {
 
     #[test]
     fn test_leases_sorting_by_core() {
-        let mut leases = vec![
+        let mut leases = [
             LeaseWithCore {
                 task: "2002".to_string(),
                 until: 100,
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_leases_sorting_none_cores_last() {
-        let mut leases = vec![
+        let mut leases = [
             LeaseWithCore {
                 task: "2003".to_string(),
                 until: 100,

--- a/crates/server/src/handlers/coretime/leases.rs
+++ b/crates/server/src/handlers/coretime/leases.rs
@@ -407,7 +407,7 @@ mod tests {
             },
         ];
 
-        let workloads = vec![
+        let workloads = [
             WorkloadInfo {
                 core: 0,
                 task: Some(2000),

--- a/crates/server/src/handlers/coretime/regions.rs
+++ b/crates/server/src/handlers/coretime/regions.rs
@@ -262,7 +262,7 @@ mod tests {
     #[test]
     fn test_decode_region_record_invalid() {
         // Not enough bytes for a valid RegionRecord
-        let bytes = vec![0x00, 0x01];
+        let bytes = [0x00, 0x01];
         let result = RegionRecord::decode(&mut &bytes[..]);
         assert!(result.is_err());
     }
@@ -370,7 +370,7 @@ mod tests {
 
     #[test]
     fn test_regions_sorting_by_core() {
-        let mut regions = vec![
+        let mut regions = [
             RegionInfo {
                 core: 52,
                 begin: 100,

--- a/crates/server/src/handlers/coretime/renewals.rs
+++ b/crates/server/src/handlers/coretime/renewals.rs
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_renewals_sorting_by_core() {
-        let mut renewals = vec![
+        let mut renewals = [
             RenewalInfo {
                 completion: None,
                 core: 3,

--- a/crates/server/src/handlers/coretime/reservations.rs
+++ b/crates/server/src/handlers/coretime/reservations.rs
@@ -236,7 +236,7 @@ mod tests {
 
     #[test]
     fn test_extract_reservation_info_multiple_reservations() {
-        let reservations = vec![
+        let reservations = [
             vec![ScheduleItem {
                 mask: [0xFF; CORE_MASK_SIZE],
                 assignment: CoreAssignment::Task(1000),

--- a/crates/server/src/handlers/pallets/common.rs
+++ b/crates/server/src/handlers/pallets/common.rs
@@ -29,7 +29,7 @@ pub enum PalletError {
     BlockResolveFailed(#[from] crate::utils::BlockResolveError),
 
     #[error("Failed to get client at block")]
-    ClientAtBlockFailed(#[source] subxt::error::OnlineClientAtBlockError),
+    ClientAtBlockFailed(#[source] Box<subxt::error::OnlineClientAtBlockError>),
 
     #[error("Bad staking block: {0}")]
     BadStakingBlock(String),
@@ -175,7 +175,7 @@ impl From<crate::utils::AtBlockError> for PalletError {
             crate::utils::AtBlockError::BlockNotFound(msg) => {
                 PalletError::BlockResolveFailed(crate::utils::BlockResolveError::NotFound(msg))
             }
-            crate::utils::AtBlockError::Client(e) => PalletError::ClientAtBlockFailed(e),
+            crate::utils::AtBlockError::Client(e) => PalletError::ClientAtBlockFailed(Box::new(e)),
         }
     }
 }

--- a/crates/server/src/handlers/rc/runtime/get_rc_runtime_code.rs
+++ b/crates/server/src/handlers/rc/runtime/get_rc_runtime_code.rs
@@ -39,7 +39,7 @@ impl From<utils::ResolveClientAtBlockError> for GetRcCodeError {
                 GetRcCodeError::BlockResolveFailed(utils::BlockResolveError::NotFound(msg))
             }
             utils::ResolveClientAtBlockError::SubxtError(e) => {
-                GetRcCodeError::ClientAtBlockFailed(Box::new(e))
+                GetRcCodeError::ClientAtBlockFailed(e)
             }
         }
     }

--- a/crates/server/src/handlers/rc/runtime/get_rc_runtime_spec.rs
+++ b/crates/server/src/handlers/rc/runtime/get_rc_runtime_spec.rs
@@ -83,7 +83,7 @@ impl From<utils::ResolveClientAtBlockError> for GetRcSpecError {
                 GetRcSpecError::BlockResolveFailed(utils::BlockResolveError::NotFound(msg))
             }
             utils::ResolveClientAtBlockError::SubxtError(e) => {
-                GetRcSpecError::ClientAtBlockFailed(Box::new(e))
+                GetRcSpecError::ClientAtBlockFailed(e)
             }
         }
     }

--- a/crates/server/src/handlers/runtime/get_code.rs
+++ b/crates/server/src/handlers/runtime/get_code.rs
@@ -35,9 +35,7 @@ impl From<utils::ResolveClientAtBlockError> for GetCodeError {
             utils::ResolveClientAtBlockError::BlockNotFound(msg) => {
                 GetCodeError::BlockResolveFailed(utils::BlockResolveError::NotFound(msg))
             }
-            utils::ResolveClientAtBlockError::SubxtError(e) => {
-                GetCodeError::ClientAtBlockFailed(Box::new(e))
-            }
+            utils::ResolveClientAtBlockError::SubxtError(e) => GetCodeError::ClientAtBlockFailed(e),
         }
     }
 }

--- a/crates/server/src/handlers/runtime/get_spec.rs
+++ b/crates/server/src/handlers/runtime/get_spec.rs
@@ -42,9 +42,7 @@ impl From<utils::ResolveClientAtBlockError> for GetSpecError {
             utils::ResolveClientAtBlockError::BlockNotFound(msg) => {
                 GetSpecError::BlockResolveFailed(utils::BlockResolveError::NotFound(msg))
             }
-            utils::ResolveClientAtBlockError::SubxtError(e) => {
-                GetSpecError::ClientAtBlockFailed(Box::new(e))
-            }
+            utils::ResolveClientAtBlockError::SubxtError(e) => GetSpecError::ClientAtBlockFailed(e),
         }
     }
 }

--- a/crates/server/src/middleware/rc_format.rs
+++ b/crates/server/src/middleware/rc_format.rs
@@ -304,19 +304,19 @@ mod tests {
             Err(_) => return Response::from_parts(parts, Body::from(bytes)),
         };
 
-        if let serde_json::Value::Array(arr) = &value {
-            if arr.is_empty() {
-                let result = serde_json::json!({
-                    "rcBlock": null,
-                    "parachainDataPerBlock": []
-                });
-                if let Ok(new_bytes) = serde_json::to_vec(&result) {
-                    parts.headers.insert(
-                        axum::http::header::CONTENT_LENGTH,
-                        axum::http::HeaderValue::from(new_bytes.len()),
-                    );
-                    return Response::from_parts(parts, Body::from(new_bytes));
-                }
+        if let serde_json::Value::Array(arr) = &value
+            && arr.is_empty()
+        {
+            let result = serde_json::json!({
+                "rcBlock": null,
+                "parachainDataPerBlock": []
+            });
+            if let Ok(new_bytes) = serde_json::to_vec(&result) {
+                parts.headers.insert(
+                    axum::http::header::CONTENT_LENGTH,
+                    axum::http::HeaderValue::from(new_bytes.len()),
+                );
+                return Response::from_parts(parts, Body::from(new_bytes));
             }
         }
 

--- a/crates/server/src/middleware/rc_format.rs
+++ b/crates/server/src/middleware/rc_format.rs
@@ -56,6 +56,9 @@ fn strip_format_param(req: Request) -> Request {
 ///
 /// Returns `Err(Response)` for early returns (no `format=object`, validation failure, non-success, non-JSON).
 /// Returns `Ok((parts, bytes, at_param))` when the response body is ready for RC transformation.
+// The `Err` variant is an axum `Response` (~128B). The no-`format=object` early return is the common
+// middleware path, so boxing the error would add a heap allocation to most requests; allow the lint here.
+#[allow(clippy::result_large_err)]
 async fn process_rc_request(
     req: Request,
     next: Next,

--- a/crates/server/src/utils/block.rs
+++ b/crates/server/src/utils/block.rs
@@ -185,7 +185,7 @@ pub async fn resolve_client_at_block(
         None => client
             .at_current_block()
             .await
-            .map_err(ResolveClientAtBlockError::SubxtError),
+            .map_err(|e| ResolveClientAtBlockError::SubxtError(Box::new(e))),
         Some(at_str) => {
             let block_id = at_str
                 .parse::<BlockId>()
@@ -208,14 +208,14 @@ pub enum ResolveClientAtBlockError {
     BlockNotFound(String),
 
     #[error("Failed to get client at block: {0}")]
-    SubxtError(OnlineClientAtBlockError),
+    SubxtError(Box<OnlineClientAtBlockError>),
 }
 
 impl From<AtBlockError> for ResolveClientAtBlockError {
     fn from(err: AtBlockError) -> Self {
         match err {
             AtBlockError::BlockNotFound(msg) => ResolveClientAtBlockError::BlockNotFound(msg),
-            AtBlockError::Client(e) => ResolveClientAtBlockError::SubxtError(e),
+            AtBlockError::Client(e) => ResolveClientAtBlockError::SubxtError(Box::new(e)),
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot-rest-api/issues/329 (bumps the pin instead of reverting it)

### Description

- Bumps the pinned CI Rust nightly from `nightly-2025-09-14` to `nightly-2026-06-16`.
- Fixes the new clippy lints the bump surfaced. The main one is `result_large_err`: four error enums stored a large subxt error (`OnlineClientAtBlockError`, ~208 bytes) by value, so it is now boxed. The rest are small, mostly auto-fixable lints.
- One hot-path case keeps a local `#[allow]` instead of boxing (see files below).
- Adds a `RELEASE.md` note so future maintainers check the nightly pin before a release.

### Files changed

- `.github/workflows/ci.yml` - bump the pinned nightly to `nightly-2026-06-16` (all 5 CI jobs).
- `crates/server/src/utils/block.rs` - box the large error in `ResolveClientAtBlockError::SubxtError`; update the conversions that build and forward it.
- `crates/server/src/handlers/blocks/types.rs` - box the error in `GetBlockHeaderError::ClientAtBlockFailed`; adjust conversions.
- `crates/server/src/handlers/coretime/common.rs` - box the error in `CoretimeError::ClientAtBlockFailed`; adjust conversion.
- `crates/server/src/handlers/pallets/common.rs` - box the error in `PalletError::ClientAtBlockFailed`; adjust conversion.
- `crates/server/src/handlers/accounts/types.rs`, `runtime/get_code.rs`, `runtime/get_spec.rs`, `rc/runtime/get_rc_runtime_code.rs`, `rc/runtime/get_rc_runtime_spec.rs` - drop now-redundant `Box::new(...)`; the upstream error is already boxed, so it is just forwarded.
- `crates/server/src/middleware/rc_format.rs` - add a function-scoped `#[allow(clippy::result_large_err)]`. The `Err` here is an axum `Response` on a common request path, so boxing it would add a heap allocation to most requests. Also includes a nested-`if` collapse.
- `crates/server/src/extractors.rs` - read the test handler's parsed fields so they are not flagged as dead code (they define the schema the rejection tests rely on, so they cannot just be removed).
- `crates/integration_tests/tests/accounts/mod.rs`, `accounts/staking_info.rs`, `accounts/staking_payouts.rs`, `coretime.rs` and `crates/server/src/handlers/coretime/leases.rs`, `regions.rs`, `renewals.rs`, `reservations.rs` - clippy auto-fixes only: collapse nested `if`s into let-chains, `vec![...]` to array, `.len() == 0` to `.is_empty()`.
- `RELEASE.md` - add a pre-release note to check and bump the CI nightly pin in a separate PR, with the verify commands.

### Verification

```bash
# install the pinned CI nightly
rustup toolchain install nightly-2026-06-16 --component clippy,rustfmt

# format (CI gate)
cargo +nightly-2026-06-16 fmt --all -- --check

# lint (same command as CI)
cargo +nightly-2026-06-16 clippy --workspace --all-features -- -D warnings

# build
cargo +nightly-2026-06-16 build --release --package server

# unit tests
cargo +nightly-2026-06-16 test --workspace --exclude integration_tests

# run (optional, needs an RPC endpoint)
SAS_SUBSTRATE_URL=wss://rpc.polkadot.io cargo +nightly-2026-06-16 run --release --bin polkadot-rest-api
```

All commands above are expected to pass (exit 0).