### PR TITLE
fix: accept any SS58 prefix on account read endpoints

### DIFF
--- a/crates/server/src/handlers/accounts/get_asset_approvals.rs
+++ b/crates/server/src/handlers/accounts/get_asset_approvals.rs
@@ -55,9 +55,9 @@ pub async fn get_asset_approvals(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<AssetApprovalQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
-    let delegate = validate_and_parse_address(&params.delegate, state.chain_info.ss58_prefix)
+    let delegate = validate_and_parse_address(&params.delegate)
         .map_err(|_| AccountsError::InvalidDelegateAddress(params.delegate.clone()))?;
 
     if params.use_rc_block {

--- a/crates/server/src/handlers/accounts/get_asset_balances.rs
+++ b/crates/server/src/handlers/accounts/get_asset_balances.rs
@@ -65,7 +65,7 @@ pub async fn get_asset_balances(
     Path(account_id): Path<String>,
     QsQuery(params): QsQuery<AssetBalancesQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     if params.use_rc_block {
         return handle_use_rc_block(state, account, params).await;

--- a/crates/server/src/handlers/accounts/get_balance_info.rs
+++ b/crates/server/src/handlers/accounts/get_balance_info.rs
@@ -58,7 +58,7 @@ pub async fn get_balance_info(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<BalanceInfoQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     if params.use_rc_block {
         return handle_use_rc_block(state, account, params).await;

--- a/crates/server/src/handlers/accounts/get_foreign_asset_balances.rs
+++ b/crates/server/src/handlers/accounts/get_foreign_asset_balances.rs
@@ -60,7 +60,7 @@ pub async fn get_foreign_asset_balances(
     Path(account_id): Path<String>,
     QsQuery(params): QsQuery<ForeignAssetBalancesQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     if params.use_rc_block {
         return handle_use_rc_block(state, account, params).await;

--- a/crates/server/src/handlers/accounts/get_pool_asset_approvals.rs
+++ b/crates/server/src/handlers/accounts/get_pool_asset_approvals.rs
@@ -57,9 +57,9 @@ pub async fn get_pool_asset_approvals(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<PoolAssetApprovalQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
-    let delegate = validate_and_parse_address(&params.delegate, state.chain_info.ss58_prefix)
+    let delegate = validate_and_parse_address(&params.delegate)
         .map_err(|_| AccountsError::InvalidDelegateAddress(params.delegate.clone()))?;
 
     if params.use_rc_block.unwrap_or(false) {

--- a/crates/server/src/handlers/accounts/get_pool_asset_balances.rs
+++ b/crates/server/src/handlers/accounts/get_pool_asset_balances.rs
@@ -56,7 +56,7 @@ pub async fn get_pool_asset_balances(
     Path(account_id): Path<String>,
     QsQuery(params): QsQuery<PoolAssetBalancesQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     if params.use_rc_block {
         return handle_use_rc_block(state, account, params).await;

--- a/crates/server/src/handlers/accounts/get_proxy_info.rs
+++ b/crates/server/src/handlers/accounts/get_proxy_info.rs
@@ -52,7 +52,7 @@ pub async fn get_proxy_info(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<ProxyInfoQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     if params.use_rc_block {
         return handle_use_rc_block(state, account, params).await;

--- a/crates/server/src/handlers/accounts/get_staking_info.rs
+++ b/crates/server/src/handlers/accounts/get_staking_info.rs
@@ -56,7 +56,7 @@ pub async fn get_staking_info(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<StakingInfoQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     if params.use_rc_block {
         return handle_use_rc_block(state, account, params).await;

--- a/crates/server/src/handlers/accounts/get_staking_payouts.rs
+++ b/crates/server/src/handlers/accounts/get_staking_payouts.rs
@@ -62,7 +62,7 @@ pub async fn get_staking_payouts(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<StakingPayoutsQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     if params.use_rc_block {
         return handle_use_rc_block(state, account, params).await;

--- a/crates/server/src/handlers/accounts/get_vesting_info.rs
+++ b/crates/server/src/handlers/accounts/get_vesting_info.rs
@@ -54,7 +54,7 @@ pub async fn get_vesting_info(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<VestingInfoQueryParams>,
 ) -> Result<Response, AccountsError> {
-    let account = validate_and_parse_address(&account_id, state.chain_info.ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     if params.use_rc_block {
         return handle_use_rc_block(state, account, params).await;

--- a/crates/server/src/handlers/accounts/utils/address.rs
+++ b/crates/server/src/handlers/accounts/utils/address.rs
@@ -291,7 +291,10 @@ mod tests {
 
         // The decoded key matches the published public key for this account.
         let expected = "0xe46d5f813e6b106d1f05542a8919ce950dc6a7693d82ed78bd9265e0fca4fc65";
-        assert_eq!(format!("0x{}", hex::encode(<[u8; 32]>::from(from_42))), expected);
+        assert_eq!(
+            format!("0x{}", hex::encode(<[u8; 32]>::from(from_42))),
+            expected
+        );
     }
 
     #[test]

--- a/crates/server/src/handlers/accounts/utils/address.rs
+++ b/crates/server/src/handlers/accounts/utils/address.rs
@@ -28,29 +28,17 @@ pub fn get_network_name(prefix: u16) -> Option<String> {
     }
 }
 
-/// Validate and parse account address (supports SS58 and hex formats)
+/// Validate and parse account address (supports SS58 and hex formats).
 ///
-/// For SS58 addresses, validates that the address uses the expected network prefix.
-/// Hex addresses (0x-prefixed) are accepted regardless of prefix.
-pub fn validate_and_parse_address(
-    addr: &str,
-    ss58_prefix: u16,
-) -> Result<AccountId32, AddressValidationError> {
-    use sp_core::crypto::Ss58AddressFormat;
-
-    // Try SS58 format first - decode and validate the prefix matches
-    if let Ok((account, version)) = AccountId32::from_ss58check_with_version(addr) {
-        let expected_format = Ss58AddressFormat::custom(ss58_prefix);
-        if version == expected_format {
-            return Ok(account);
-        }
-        // Address decoded but wrong network prefix
-        return Err(AddressValidationError(format!(
-            "Address '{}' uses SS58 prefix {} but expected prefix {}",
-            addr,
-            u16::from(version),
-            ss58_prefix
-        )));
+/// Validates checksum and length but is **lenient about the SS58 network
+/// prefix**: an account *is* its 32-byte public key, and the SS58 prefix is
+/// display-only metadata (`System.Account` is keyed by the raw bytes). Any
+/// valid prefix — and hex (`0x…`) addresses, which carry no prefix — decode to
+/// the same `AccountId32`.
+pub fn validate_and_parse_address(addr: &str) -> Result<AccountId32, AddressValidationError> {
+    // Try SS58 format first - decode and accept any network prefix.
+    if let Ok((account, _version)) = AccountId32::from_ss58check_with_version(addr) {
+        return Ok(account);
     }
 
     // Try hex format (0x-prefixed, 32 bytes)
@@ -241,58 +229,76 @@ pub fn validate_address(address: &str) -> AddressDetails {
 mod tests {
     use super::*;
 
-    // Common SS58 prefixes for testing
-    const POLKADOT_PREFIX: u16 = 0;
-    const KUSAMA_PREFIX: u16 = 2;
-    const SUBSTRATE_PREFIX: u16 = 42;
-
     #[test]
     fn test_address_validation_hex() {
-        // Alice's address in hex - should work with any prefix
+        // Alice's address in hex - carries no prefix, always accepted.
         let addr = "0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d";
-        assert!(validate_and_parse_address(addr, POLKADOT_PREFIX).is_ok());
-        assert!(validate_and_parse_address(addr, KUSAMA_PREFIX).is_ok());
+        assert!(validate_and_parse_address(addr).is_ok());
     }
 
     #[test]
     fn test_address_validation_ss58_polkadot() {
-        // Alice's address in SS58 (Polkadot prefix 0)
+        // Alice's address in SS58 (Polkadot prefix 0) decodes fine.
         let addr = "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5";
-        // Should succeed with correct prefix
-        assert!(validate_and_parse_address(addr, POLKADOT_PREFIX).is_ok());
-        // Should fail with wrong prefix
-        assert!(validate_and_parse_address(addr, KUSAMA_PREFIX).is_err());
+        assert!(validate_and_parse_address(addr).is_ok());
     }
 
     #[test]
     fn test_address_validation_ss58_substrate() {
-        // Alice's address in SS58 (Substrate generic prefix 42)
+        // Alice's address in SS58 (Substrate generic prefix 42) decodes fine;
+        // the prefix is no longer enforced against the chain.
         let addr = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
-        // Should succeed with correct prefix
-        assert!(validate_and_parse_address(addr, SUBSTRATE_PREFIX).is_ok());
-        // Should fail with wrong prefix
-        assert!(validate_and_parse_address(addr, POLKADOT_PREFIX).is_err());
+        assert!(validate_and_parse_address(addr).is_ok());
     }
 
     #[test]
     fn test_address_validation_invalid() {
         let addr = "invalid-address";
-        assert!(validate_and_parse_address(addr, POLKADOT_PREFIX).is_err());
+        assert!(validate_and_parse_address(addr).is_err());
     }
 
     #[test]
     fn test_address_validation_short_hex() {
         let addr = "0x1234"; // Too short
-        assert!(validate_and_parse_address(addr, POLKADOT_PREFIX).is_err());
+        assert!(validate_and_parse_address(addr).is_err());
     }
 
     #[test]
-    fn test_address_validation_wrong_prefix_error_message() {
-        // Polkadot address with Kusama prefix should give informative error
-        let addr = "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5";
-        let result = validate_and_parse_address(addr, KUSAMA_PREFIX);
-        assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(err.0.contains("prefix"));
+    fn test_address_validation_cross_prefix_same_account() {
+        // The same 32-byte key encoded under different SS58 prefixes must
+        // decode to the same AccountId32, regardless of the chain's prefix.
+        // (prefix is display-only; System.Account is keyed by the raw bytes.)
+        let polkadot = "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp5"; // prefix 0
+        let substrate = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"; // prefix 42
+
+        let from_polkadot = validate_and_parse_address(polkadot).unwrap();
+        let from_substrate = validate_and_parse_address(substrate).unwrap();
+        assert_eq!(from_polkadot, from_substrate);
+    }
+
+    #[test]
+    fn test_address_validation_generic_prefix_accepted_on_prefix_0_chain() {
+        // A generic (prefix-42) encoding of a key must be accepted regardless of
+        // the chain's prefix and resolve to the same AccountId32 as its prefix-0
+        // encoding.
+        let prefix_42 = "5HEDGMG7mYqh18Xs4BZpYZ3u7EPWUJ8hPDTJhq3cDZh1ztRW";
+        let prefix_0 = "16AWQgXBdL7ASfYP1pcpght3xrPAAbgqTiBns82xmeiYBEQm";
+
+        let from_42 = validate_and_parse_address(prefix_42)
+            .expect("generic prefix-42 address must be accepted");
+        let from_0 = validate_and_parse_address(prefix_0).unwrap();
+        assert_eq!(from_42, from_0);
+
+        // The decoded key matches the published public key for this account.
+        let expected = "0xe46d5f813e6b106d1f05542a8919ce950dc6a7693d82ed78bd9265e0fca4fc65";
+        assert_eq!(format!("0x{}", hex::encode(<[u8; 32]>::from(from_42))), expected);
+    }
+
+    #[test]
+    fn test_address_validation_bad_checksum_still_rejected() {
+        // Leniency is only about the network prefix. A corrupted checksum
+        // (last char flipped) must still be rejected.
+        let bad = "15oF4uVJwmo4TdGW7VfQxNLavjCXviqxT9S1MgbjMNHr6Sp6";
+        assert!(validate_and_parse_address(bad).is_err());
     }
 }

--- a/crates/server/src/handlers/rc/accounts/get_balance_info.rs
+++ b/crates/server/src/handlers/rc/accounts/get_balance_info.rs
@@ -56,9 +56,7 @@ pub async fn get_balance_info(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<RcBalanceInfoQueryParams>,
 ) -> Result<Response, AccountsError> {
-    // Get the relay chain ss58_prefix for address validation
-    let rc_ss58_prefix = get_relay_chain_ss58_prefix(&state).await?;
-    let account = validate_and_parse_address(&account_id, rc_ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     // Get the relay chain client and info
     let (rc_client, rc_rpc_client, rc_rpc, rc_spec_name) = get_relay_chain_access(&state).await?;
@@ -90,19 +88,6 @@ pub async fn get_balance_info(
 // ================================================================================================
 // Relay Chain Access
 // ================================================================================================
-
-/// Get the SS58 prefix for the relay chain
-async fn get_relay_chain_ss58_prefix(state: &AppState) -> Result<u16, AccountsError> {
-    if state.chain_info.chain_type == ChainType::Relay {
-        return Ok(state.chain_info.ss58_prefix);
-    }
-
-    state
-        .get_relay_chain_info()
-        .await
-        .map(|info| info.ss58_prefix)
-        .map_err(AccountsError::RelayChain)
-}
 
 /// Get access to relay chain client and RPC
 async fn get_relay_chain_access(

--- a/crates/server/src/handlers/rc/accounts/get_proxy_info.rs
+++ b/crates/server/src/handlers/rc/accounts/get_proxy_info.rs
@@ -49,7 +49,7 @@ pub async fn get_proxy_info(
 ) -> Result<Response, AccountsError> {
     // Get the relay chain ss58_prefix for address validation
     let rc_ss58_prefix = get_relay_chain_ss58_prefix(&state).await?;
-    let account = validate_and_parse_address(&account_id, rc_ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     // Get the relay chain client and info
     let (rc_client, rc_rpc_client, rc_rpc) = get_relay_chain_access(&state).await?;

--- a/crates/server/src/handlers/rc/accounts/get_staking_info.rs
+++ b/crates/server/src/handlers/rc/accounts/get_staking_info.rs
@@ -55,7 +55,7 @@ pub async fn get_staking_info(
 ) -> Result<Response, AccountsError> {
     // Get the relay chain ss58_prefix for address validation
     let rc_ss58_prefix = get_relay_chain_ss58_prefix(&state).await?;
-    let account = validate_and_parse_address(&account_id, rc_ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     // Get the relay chain client and info
     let (rc_client, rc_rpc_client, rc_rpc) = get_relay_chain_access(&state).await?;

--- a/crates/server/src/handlers/rc/accounts/get_staking_payouts.rs
+++ b/crates/server/src/handlers/rc/accounts/get_staking_payouts.rs
@@ -60,7 +60,7 @@ pub async fn get_staking_payouts(
 ) -> Result<Response, AccountsError> {
     // Get the relay chain ss58_prefix for address validation
     let rc_ss58_prefix = get_relay_chain_ss58_prefix(&state).await?;
-    let account = validate_and_parse_address(&account_id, rc_ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     // Get the relay chain client and info
     let (rc_client, rc_rpc_client, rc_rpc) = get_relay_chain_access(&state).await?;

--- a/crates/server/src/handlers/rc/accounts/get_vesting_info.rs
+++ b/crates/server/src/handlers/rc/accounts/get_vesting_info.rs
@@ -50,9 +50,7 @@ pub async fn get_vesting_info(
     Path(account_id): Path<String>,
     JsonQuery(params): JsonQuery<RcVestingInfoQueryParams>,
 ) -> Result<Response, AccountsError> {
-    // Get the relay chain ss58_prefix for address validation
-    let rc_ss58_prefix = get_relay_chain_ss58_prefix(&state).await?;
-    let account = validate_and_parse_address(&account_id, rc_ss58_prefix)?;
+    let account = validate_and_parse_address(&account_id)?;
 
     // Get the relay chain client and info
     let (rc_client, rc_rpc_client, rc_rpc) = get_relay_chain_access(&state).await?;
@@ -78,19 +76,6 @@ pub async fn get_vesting_info(
 // ================================================================================================
 // Relay Chain Access
 // ================================================================================================
-
-/// Get the SS58 prefix for the relay chain
-async fn get_relay_chain_ss58_prefix(state: &AppState) -> Result<u16, AccountsError> {
-    if state.chain_info.chain_type == ChainType::Relay {
-        return Ok(state.chain_info.ss58_prefix);
-    }
-
-    state
-        .get_relay_chain_info()
-        .await
-        .map(|info| info.ss58_prefix)
-        .map_err(AccountsError::RelayChain)
-}
 
 /// Get access to relay chain client and RPC
 async fn get_relay_chain_access(state: &AppState) -> Result<RelayChainAccess, AccountsError> {

--- a/scripts/start-server-with-fallback.sh
+++ b/scripts/start-server-with-fallback.sh
@@ -34,50 +34,53 @@ fi
 
 # Define RPC URLs per chain (primary first, then fallbacks)
 case $CHAIN in
+    # NOTE: Parity-hosted RPCs (*.polkadot.io) are rate-limited; keep them last.
     polkadot)
         RPC_URLS=(
-            # "wss://rpc.polkadot.io" NOTE: Do not use parity hosted RPC nodes because of rate limiting
-            "wss://polkadot.dotters.network"
             "wss://polkadot-rpc.n.dwellir.com"
+            "wss://rpc-polkadot.luckyfriday.io"
+            "wss://polkadot.api.onfinality.io/public-ws"
         )
         ;;
     kusama)
         RPC_URLS=(
-            "wss://kusama.dotters.network"
             "wss://kusama-rpc.n.dwellir.com"
             "wss://kusama.api.onfinality.io/public-ws"
         )
         ;;
     asset-hub-polkadot)
         RPC_URLS=(
-            "wss://asset-hub-polkadot.dotters.network"
-            "wss://statemint.api.onfinality.io/public-ws"
+            "wss://asset-hub-polkadot-rpc.n.dwellir.com"
+            "wss://rpc-asset-hub-polkadot.luckyfriday.io"
+            "wss://polkadot-asset-hub-rpc.polkadot.io" # Parity-hosted, rate-limited; last resort
         )
-        RELAY_URL="wss://polkadot.dotters.network"
+        RELAY_URL="wss://polkadot-rpc.n.dwellir.com"
         ;;
     asset-hub-kusama)
         RPC_URLS=(
-            "wss://asset-hub-kusama.dotters.network"
             "wss://asset-hub-kusama-rpc.n.dwellir.com"
+            "wss://rpc-asset-hub-kusama.luckyfriday.io"
         )
-        RELAY_URL="wss://kusama.dotters.network"
+        RELAY_URL="wss://kusama-rpc.n.dwellir.com"
         ;;
     westend)
         RPC_URLS=(
-            "wss://westend-rpc.dwellir.com"
-            "wss://westend-rpc-tn.dwellir.com"
+            "wss://westend-rpc.n.dwellir.com"
+            "wss://westend-rpc.polkadot.io" # Parity-hosted, rate-limited; last resort
         )
         ;;
     coretime-kusama)
         RPC_URLS=(
-            "wss://coretime-kusama.dotters.network"
             "wss://coretime-kusama-rpc.n.dwellir.com"
+            "wss://rpc-coretime-kusama.luckyfriday.io"
+            "wss://coretime-kusama.api.onfinality.io/public-ws"
         )
         ;;
     coretime-polkadot)
         RPC_URLS=(
-            "wss://coretime-polkadot.dotters.network"
             "wss://coretime-polkadot-rpc.n.dwellir.com"
+            "wss://rpc-coretime-polkadot.luckyfriday.io"
+            "wss://coretime-polkadot.api.onfinality.io/public-ws"
         )
         ;;
     *)


### PR DESCRIPTION
Closes https://github.com/paritytech/polkadot-rest-api/issues/362

### Description
- Account read endpoints (balance-info, staking-info, vesting-info, proxy-info, asset and pool balances, staking-payouts) returned 400 when the address SS58 prefix did not match the chain.
- An account is its 32-byte public key; the SS58 prefix is only a display label. The check rejected valid requests.
- Fix: ignore the prefix. Any valid SS58 or hex address is accepted and resolved to the same account. Checksum and length are still checked, so malformed addresses are still rejected.
- Read-only change. No transaction or signing path is touched.

### Changes
- `crates/server/src/handlers/accounts/utils/address.rs`: removed the ss58_prefix parameter and the wrong-prefix rejection from validate_and_parse_address. It now accepts any prefix and returns the 32-byte account. Updated tests to check cross-prefix acceptance and that bad checksums still fail.
- `crates/server/src/handlers/accounts/` (10 handlers) and `rc/accounts/get_proxy_info.rs`, `get_staking_info.rs`, `get_staking_payouts.rs`: dropped the prefix argument from the validate call. No other change.
- `crates/server/src/handlers/rc/accounts/get_balance_info.rs` and `get_vesting_info.rs`: dropped the prefix argument and removed the helper that fetched the relay chain prefix over RPC (it was only used for validation).

### Consistency with the rest of the codebase
- `validate_and_parse_address` was the only place that enforced the SS58 prefix.
- Everything else already ignores it: transaction submit and dry-run decode addresses without a prefix check, and storage query decoding does the same.
- Response encoding already normalizes every returned address to the chain prefix.
- So this change makes account reads behave like the rest of the codebase. It removes an inconsistency rather than adding new behavior.

### Verification
- `cargo build --release --package polkadot-rest-api`
- `cargo check --package polkadot-rest-api --all-targets`
- `cargo test --package polkadot-rest-api --lib`
- `cargo test --package polkadot-rest-api --lib address::tests`
- `cargo clippy --package polkadot-rest-api --all-targets`
- `cargo fmt --check`
- Manual run + repro check:
  ```
  export SAS_SUBSTRATE_URL=wss://rpc.polkadot.io
  cargo run --release --bin polkadot-rest-api
  # in another shell:
  curl -s "http://127.0.0.1:8080/v1/accounts/5HEDGMG7mYqh18Xs4BZpYZ3u7EPWUJ8hPDTJhq3cDZh1ztRW/balance-info"
  # expect HTTP 200 with zeroed balance (was 400 before the fix)
  ```

### Additional change to fix failing CI tests
- `scripts/start-server-with-fallback.sh` listed `wss://<chain>.dotters.network` URLs as primary RPCs.
- Those subdomains no longer resolve and resulted in failing CI integration tests so they were removed and other, verified reachable rpc urls were added.
- Also added Parity RPCs as a last resort with a note that they are rate limited.
