### PR TITLE
fix: decode era from the extensions payload range, not raw prefixed bytes

### DIFF
--- a/crates/server/src/handlers/blocks/processing/extrinsics.rs
+++ b/crates/server/src/handlers/blocks/processing/extrinsics.rs
@@ -200,9 +200,21 @@ async fn extract_extrinsics_impl(
                 .address_bytes()
                 .ok_or(GetBlockError::MissingAddressBytes)?;
 
-            // Try to extract era from raw extrinsic bytes
-            // Era comes right after address and signature in the SignedExtra/TransactionExtension
-            let era_info = utils::extract_era_from_extrinsic_bytes(extrinsic.bytes());
+            // Try to extract era from the transaction extensions payload. The payload
+            // range is computed by frame-decode, so it is correct regardless of the
+            // compact length prefix that `extrinsic.bytes()` carries (the raw block
+            // body entry is length-prefixed), and it already excludes the extension
+            // version byte for v5 General extrinsics. Era is the first explicit
+            // field of the extensions payload.
+            //
+            // Note: do NOT pass `extrinsic.bytes()` to
+            // `extract_era_from_extrinsic_bytes` here — those bytes include the
+            // compact length prefix, which that parser would misread as the
+            // version byte (see its docs).
+            let era_info = extrinsic.transaction_extensions_bytes().and_then(|ext| {
+                let mut offset = 0;
+                utils::decode_era_from_bytes(ext, &mut offset)
+            });
 
             let signer_hex = format!("0x{}", hex::encode(addr_bytes));
             let signer_ss58 = utils::decode_address_to_ss58(&signer_hex, ss58_prefix)

--- a/crates/server/src/handlers/blocks/processing/extrinsics.rs
+++ b/crates/server/src/handlers/blocks/processing/extrinsics.rs
@@ -398,3 +398,109 @@ async fn extract_extrinsics_impl(
 
     Ok(result)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_fixtures::{TEST_BLOCK_NUMBER, TEST_GENESIS_HASH, mock_rpc_client_builder};
+    use serde_json::json;
+    use std::sync::{Arc, Mutex};
+    use subxt_rpcs::client::RpcClient;
+    use subxt_rpcs::client::mock_rpc_client::Json as MockJson;
+
+    /// Real Asset Hub extrinsic (block 17742975, #2), exactly as it appears
+    /// in a `chain_getBlock` response: the block-body entry is
+    /// length-prefixed (compact prefix `0xbd 0x01`). Era: Mortal(32, 11).
+    const REAL_PREFIXED_EXTRINSIC: &str = "0xbd01840072284f32719a49037a79da881b91b44bf642395ecba92b241619e21fb1c8a57a01b250abd5b7715a993a111d0db2f6742a8b108fd5a700b5c9e443f9fb14f79938d668ba315e48121b2bd2584b104014e6ede84fe35b77adcc9ff8030de5daef8ab4003e7b0100000000000000";
+
+    /// `MakeWriter` that appends everything to a shared buffer so a test can
+    /// assert on emitted tracing output.
+    #[derive(Clone, Default)]
+    struct CaptureWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for CaptureWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(buf);
+            Ok(buf.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for CaptureWriter {
+        type Writer = CaptureWriter;
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Call-site regression test for the length-prefix era bug: process a
+    /// block whose body entry is a real length-prefixed extrinsic and assert
+    /// both the era output and that no era-decode warning is emitted.
+    ///
+    /// The warning assertion is the discriminating part: before #370 this
+    /// call site passed `extrinsic.bytes()` (which include the compact
+    /// length prefix) to `extract_era_from_extrinsic_bytes` for every signed
+    /// extrinsic, which misread the prefix byte as the version byte, walked
+    /// garbage, and logged `Failed to decode Era from bytes at offset 0` —
+    /// the WARN flood reported in #369. Reverting the call site to the
+    /// prefixed-bytes walk turns this test red.
+    #[tokio::test]
+    async fn test_extract_extrinsics_prefixed_body_entry_era_without_warning() {
+        let mock = mock_rpc_client_builder()
+            .method_handler("chain_getBlock", async |_params| {
+                MockJson(json!({
+                    "block": {
+                        "header": {
+                            "number": format!("0x{:x}", TEST_BLOCK_NUMBER),
+                            "parentHash": TEST_GENESIS_HASH,
+                            "stateRoot": TEST_GENESIS_HASH,
+                            "extrinsicsRoot": TEST_GENESIS_HASH,
+                            "digest": { "logs": [] }
+                        },
+                        "extrinsics": [REAL_PREFIXED_EXTRINSIC]
+                    },
+                    "justifications": null
+                }))
+            })
+            .build();
+
+        let rpc_client = RpcClient::new(mock);
+        let client = subxt::OnlineClient::<subxt::SubstrateConfig>::from_rpc_client(rpc_client)
+            .await
+            .expect("Failed to create OnlineClient");
+        let at_block = client
+            .at_current_block()
+            .await
+            .expect("Failed at_current_block");
+
+        // Capture WARN-level tracing output while extracting. This relies on
+        // the current-thread tokio runtime of #[tokio::test]: set_default is
+        // thread-local, so it sees everything the extraction emits.
+        let captured = CaptureWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_max_level(tracing::Level::WARN)
+            .with_writer(captured.clone())
+            .finish();
+        let _guard = tracing::subscriber::set_default(subscriber);
+
+        let extrinsics = extract_extrinsics_with_client(&at_block, TEST_BLOCK_NUMBER)
+            .await
+            .expect("extraction should succeed");
+
+        assert_eq!(extrinsics.len(), 1);
+        assert_eq!(
+            extrinsics[0].era.mortal_era,
+            Some(vec!["32".to_string(), "11".to_string()])
+        );
+        assert_eq!(extrinsics[0].era.immortal_era, None);
+
+        let logs = String::from_utf8(captured.0.lock().unwrap().clone()).unwrap();
+        assert!(
+            !logs.contains("Failed to decode Era"),
+            "era decode warning emitted while processing a length-prefixed \
+             block-body entry (the #369 WARN flood):\n{logs}"
+        );
+    }
+}

--- a/crates/server/src/handlers/transaction/parse.rs
+++ b/crates/server/src/handlers/transaction/parse.rs
@@ -603,4 +603,39 @@ mod tests {
         assert_eq!(json["error"], "Failed to parse transaction.");
         assert_eq!(json["transaction"], "0x1234");
     }
+
+    /// Call-site regression test: feed a real length-prefixed extrinsic
+    /// through the full parse path and pin the era output.
+    ///
+    /// `tx_bytes` here carry the compact length prefix (as required by
+    /// `decode_extrinsic`), so every byte range used by
+    /// `extract_signed_info` must be prefix-aware. With Asset Hub metadata
+    /// the era resolves via the named `CheckMortality` extension (its range
+    /// comes from frame-decode and is prefix-agnostic); the payload-range
+    /// fallback for metadatas without a named mortality extension is covered
+    /// by the util-layer tests in `utils/extrinsic.rs`.
+    #[tokio::test]
+    async fn test_parse_real_prefixed_extrinsic_decodes_mortal_era() {
+        use crate::test_fixtures::mock_rpc_client_builder;
+        use subxt_rpcs::client::RpcClient;
+
+        let rpc_client = RpcClient::new(mock_rpc_client_builder().build());
+        let client = subxt::OnlineClient::<subxt::SubstrateConfig>::from_rpc_client(rpc_client)
+            .await
+            .expect("Failed to create OnlineClient");
+
+        // Real Asset Hub extrinsic (block 17742975, #2), exactly as
+        // chain_getBlock returns it — the compact length prefix 0xbd01 is
+        // still attached. Known era: Mortal(period=32, phase=11).
+        let body = ParseRequest {
+            tx: Some("0xbd01840072284f32719a49037a79da881b91b44bf642395ecba92b241619e21fb1c8a57a01b250abd5b7715a993a111d0db2f6742a8b108fd5a700b5c9e443f9fb14f79938d668ba315e48121b2bd2584b104014e6ede84fe35b77adcc9ff8030de5daef8ab4003e7b0100000000000000".to_string()),
+        };
+        let era = parse_internal(&client, 0, body).await.unwrap().0.era;
+
+        assert_eq!(
+            era.mortal_era,
+            Some(vec!["32".to_string(), "11".to_string()])
+        );
+        assert_eq!(era.immortal_era, None);
+    }
 }

--- a/crates/server/src/handlers/transaction/parse.rs
+++ b/crates/server/src/handlers/transaction/parse.rs
@@ -477,9 +477,22 @@ fn extract_signed_info(
             }
         }
 
-        // Use decoded era, or fallback to extracting from raw bytes, or default to immortal
+        // Use decoded era, or fall back to decoding it at the start of the
+        // extensions payload (era is the first explicit extension field), or
+        // default to immortal. The payload range comes from frame-decode, so
+        // it is correct even though `tx_bytes` carries the compact length
+        // prefix (decode_extrinsic requires it), and it already excludes the
+        // extension version byte for v5 General extrinsics.
+        //
+        // Note: do NOT pass `tx_bytes` to `extract_era_from_extrinsic_bytes`
+        // here — those bytes include the compact length prefix, which that
+        // parser would misread as the version byte (see its docs).
         let era = era_value
-            .or_else(|| utils::extract_era_from_extrinsic_bytes(tx_bytes))
+            .or_else(|| {
+                let ext_payload = &tx_bytes[extensions.range()];
+                let mut offset = 0;
+                utils::decode_era_from_bytes(ext_payload, &mut offset)
+            })
             .unwrap_or(EraInfo {
                 immortal_era: Some("0x00".to_string()),
                 mortal_era: None,
@@ -487,11 +500,14 @@ fn extract_signed_info(
 
         (nonce_value, tip_value, era)
     } else {
-        // No extensions - try to extract era from raw bytes
-        let era = utils::extract_era_from_extrinsic_bytes(tx_bytes).unwrap_or(EraInfo {
+        // No extensions payload - there is no era to decode; default to
+        // immortal. (The previous fallback passed the length-prefixed
+        // `tx_bytes` to `extract_era_from_extrinsic_bytes`, which misparsed
+        // the compact length prefix as the version byte.)
+        let era = EraInfo {
             immortal_era: Some("0x00".to_string()),
             mortal_era: None,
-        });
+        };
         (None, None, era)
     };
 

--- a/crates/server/src/utils/extrinsic.rs
+++ b/crates/server/src/utils/extrinsic.rs
@@ -137,7 +137,21 @@ pub fn decode_era_from_bytes(bytes: &[u8], offset: &mut usize) -> Option<EraInfo
 ///
 /// # Arguments
 ///
-/// * `bytes` - Raw extrinsic bytes from `extrinsic.bytes()` (without length prefix)
+/// * `bytes` - Raw extrinsic bytes **without** the compact length prefix
+///   (i.e. starting at the version byte).
+///
+/// # ⚠️ Length prefix warning
+///
+/// subxt's `ExtrinsicDetails::bytes()` returns the raw block-body entry,
+/// which **includes** the compact length prefix (frame-decode consumes that
+/// prefix as the first step of `decode_extrinsic`). Passing such bytes here
+/// misparses the prefix as the version byte: depending on the encoded
+/// length, the extrinsic is either silently misreported as immortal (prefix
+/// high bit unset) or parsed as garbage, typically failing with
+/// "Invalid period and phase" (prefix high bit set). Prefer decoding era
+/// from the extensions payload range provided by frame-decode/subxt
+/// (`transaction_extensions_bytes()` / `ExtrinsicExtensions::range()`),
+/// which is prefix-agnostic and also correct for v5 General extrinsics.
 ///
 /// # Returns
 ///
@@ -618,5 +632,58 @@ mod tests {
             Some(vec!["64".to_string(), "19".to_string()])
         );
         assert_eq!(offset, 2, "Should consume both era bytes");
+    }
+
+    /// Real Polkadot Asset Hub extrinsic (block 17742975, extrinsic #2),
+    /// as returned by `chain_getBlock`: the entry is length-prefixed
+    /// (`0xbd 0x01` compact prefix), version 0x84 (v4 signed), Sr25519
+    /// signature, era bytes `0xb4 0x00` => Mortal(period=32, phase=11).
+    const REAL_PREFIXED_EXTRINSIC: &str = "bd01840072284f32719a49037a79da881b91b44bf642395ecba92b241619e21fb1c8a57a01b250abd5b7715a993a111d0db2f6742a8b108fd5a700b5c9e443f9fb14f79938d668ba315e48121b2bd2584b104014e6ede84fe35b77adcc9ff8030de5daef8ab4003e7b0100000000000000";
+
+    #[test]
+    fn test_extract_era_real_extrinsic_without_length_prefix() {
+        // Strip the 2-byte compact length prefix: the parser expects bytes
+        // starting at the version byte and then finds Mortal(32, 11).
+        let full = hex::decode(REAL_PREFIXED_EXTRINSIC).unwrap();
+        let body = &full[2..];
+
+        let era = extract_era_from_extrinsic_bytes(body).expect("era should decode");
+        assert_eq!(era.immortal_era, None);
+        assert_eq!(
+            era.mortal_era,
+            Some(vec!["32".to_string(), "11".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_extract_era_misparses_length_prefixed_bytes() {
+        // Regression guard for the bug where subxt `ExtrinsicDetails::bytes()`
+        // (which INCLUDES the compact length prefix) was passed to this
+        // function: the prefix byte 0xbd has the high bit set, so it was
+        // misread as a signed version byte and the walk landed on garbage,
+        // failing Era::decode with "Invalid period and phase". The correct
+        // Mortal(32, 11) must never be produced from the prefixed bytes.
+        let full = hex::decode(REAL_PREFIXED_EXTRINSIC).unwrap();
+
+        let era = extract_era_from_extrinsic_bytes(&full);
+        assert!(
+            era.is_none(),
+            "length-prefixed bytes must not decode to a (corrupt) era, got {era:?}"
+        );
+    }
+
+    #[test]
+    fn test_decode_era_from_extensions_payload_first_bytes() {
+        // The fixed call sites decode era from the extensions payload range
+        // (era is the first explicit extension field). For the real
+        // extrinsic above the payload starts with 0xb4 0x00 => Mortal(32, 11).
+        let payload = [0xb4, 0x00, 0x3e, 0x7b, 0x01];
+        let mut offset = 0;
+        let era = decode_era_from_bytes(&payload, &mut offset).expect("era should decode");
+        assert_eq!(
+            era.mortal_era,
+            Some(vec!["32".to_string(), "11".to_string()])
+        );
+        assert_eq!(offset, 2);
     }
 }


### PR DESCRIPTION
Fixes #369

## What

Decode era from the **transaction extensions payload range** (computed by frame-decode) instead of hand-walking `[version][address][signature]` over bytes that actually include the compact length prefix.

Fixes the `WARN … Failed to decode Era from bytes at offset 0: "Invalid period and phase"` flood (`extrinsic.rs:123`) and — more importantly — the silently wrong era data it implies.

## Root cause

`extract_era_from_extrinsic_bytes` expects bytes starting at the version byte, but both call sites pass **length-prefixed** bytes:

- **blocks processing** passes `extrinsic.bytes()`: subxt returns the raw block-body entry, which is length-prefixed — frame-decode's `decode_extrinsic` consumes a `Compact<u64>` length as its first step, and subxt's byte ranges (address/signature/extensions) are all relative to the prefixed entry.
- **transaction parse** passes `tx_bytes`: these must be length-prefixed or the earlier `decode_extrinsic(&mut &tx_bytes[..], ...)` would have failed.

So the first prefix byte is misread as the version byte. Measured over 103 real Polkadot Asset Hub signed extrinsics: **~77% silently misreported as immortal** (prefix high bit unset → "unsigned"), **~10% warn `Invalid period and phase`**, **~10% return corrupt-but-plausible mortalEra values**, ~4% unknown-variant warnings.

## Changes

- `handlers/blocks/processing/extrinsics.rs`: use `extrinsic.transaction_extensions_bytes()` + `decode_era_from_bytes`. The range is prefix-agnostic and `ExtrinsicExtensions::range()` excludes the extension version byte, so this is also correct for v5 General extrinsics.
- `handlers/transaction/parse.rs`: fallback (no named `CheckMortality`/`CheckEra` matched) now decodes era at `&tx_bytes[extensions.range()]`; the no-extensions branch defaults to immortal instead of walking prefixed bytes.
- `utils/extrinsic.rs`: document the length-prefix hazard on `extract_era_from_extrinsic_bytes`; add regression tests using a real length-prefixed Asset Hub extrinsic (block 17742975 #2, era `Mortal(32, 11)`):
  - prefix stripped → decodes `Mortal(32, 11)`
  - prefixed (as previously called) → must not produce a (corrupt) era
  - extensions-payload first bytes → `Mortal(32, 11)` (the new call-site behavior)

## Testing

- `cargo test -p polkadot-rest-api --lib`: 553 passed, 0 failed
- `cargo clippy`: clean
