### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,16 @@
 version: 2
 updates:
   # Keep the SHA-pinned GitHub Actions fresh. Dependabot bumps the pinned
-  # commit hash (and its `# vN` comment) via reviewable PRs, so pinning stays
-  # safe without going stale. See issue #365.
+  # commit hash (and its `# vX.Y.Z` comment) via reviewable PRs, so pinning
+  # stays safe without going stale.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    # Wait before adopting a brand-new release — a compromised or broken
+    # version is often yanked within days (zizmor: dependabot-cooldown).
+    cooldown:
+      default-days: 7
     # Conventional prefix so PR titles pass the pr-title check (semantic.yml).
     commit-message:
       prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions fresh. Dependabot bumps the pinned
+  # commit hash (and its `# vN` comment) via reviewable PRs, so pinning stays
+  # safe without going stale. See issue #365.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    # Conventional prefix so PR titles pass the pr-title check (semantic.yml).
+    commit-message:
+      prefix: "ci"
+    # One grouped PR per week instead of one per action.
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -115,7 +115,7 @@ jobs:
           pkill -f polkadot-rest-api || true
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-results
           path: artifacts/
@@ -130,12 +130,12 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 
       - name: Download local benchmark results
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: benchmark-results
           path: artifacts
@@ -157,7 +157,7 @@ jobs:
           cat artifacts/comparison_results.json
 
       - name: Store comparison result on GitHub Pages
-        uses: benchmark-action/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00 # v1
+        uses: benchmark-action/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00 # v1.20.5
         with:
           tool: 'customBiggerIsBetter'
           output-file-path: artifacts/comparison_results.json
@@ -174,12 +174,12 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
 
       - name: Download benchmark results
-        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:
           name: benchmark-results
           path: artifacts
@@ -190,7 +190,7 @@ jobs:
           cat artifacts/benchmark_results.json
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00 # v1
+        uses: benchmark-action/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00 # v1.20.5
         with:
           tool: 'customSmallerIsBetter'
           output-file-path: artifacts/benchmark_results.json

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -9,16 +9,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: the benchmark job only reads the repo; the publish jobs
+# below elevate to contents:write to push results to the gh-pages branch.
+permissions:
+  contents: read
+
 jobs:
   benchmark:
     name: benchmark
     runs-on: ubuntu-latest
     container:
-      image: ubuntu:22.04
+      image: ubuntu:22.04@sha256:0e0a0fc6d18feda9db1590da249ac93e8d5abfea8f4c3c0c849ce512b5ef8982
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install dependencies
         run: |
@@ -48,7 +55,7 @@ jobs:
         run: |
           MAX_RETRIES=3
           WAIT_PER_ATTEMPT=60
-          
+
           for attempt in $(seq 1 $MAX_RETRIES); do
             echo "Waiting for server to be ready (attempt $attempt/$MAX_RETRIES)..."
             for i in $(seq 1 $WAIT_PER_ATTEMPT); do
@@ -59,7 +66,7 @@ jobs:
               [ $((i % 15)) -eq 0 ] && echo "  Attempt $i/${WAIT_PER_ATTEMPT}: API not ready yet, retrying in 1s..."
               sleep 1
             done
-            
+
             if [ $attempt -lt $MAX_RETRIES ]; then
               echo "✗ Server not ready after ${WAIT_PER_ATTEMPT}s, retrying..."
               if [ -f server.pid ]; then
@@ -73,7 +80,7 @@ jobs:
               sleep 5
             fi
           done
-          
+
           echo "✗ Server failed to start after $MAX_RETRIES attempts"
           cat server.log
           exit 1
@@ -83,7 +90,7 @@ jobs:
           echo "Running benchmarks..."
           HARDWARE_PROFILE="ci_runner"
           SCENARIO="medium_load"
-          
+
           for benchmark_dir in benchmarks/*/; do
             BENCHMARK_NAME=$(basename "$benchmark_dir")
             # Skip if no lua file (not a benchmark directory)
@@ -108,7 +115,7 @@ jobs:
           pkill -f polkadot-rest-api || true
 
       - name: Upload benchmark results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: benchmark-results
           path: artifacts/
@@ -119,14 +126,16 @@ jobs:
     needs: [benchmark]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # github-action-benchmark pushes comparison data to the gh-pages branch
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Download local benchmark results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: benchmark-results
           path: artifacts
@@ -148,7 +157,7 @@ jobs:
           cat artifacts/comparison_results.json
 
       - name: Store comparison result on GitHub Pages
-        uses: benchmark-action/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00
+        uses: benchmark-action/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00 # v1
         with:
           tool: 'customBiggerIsBetter'
           output-file-path: artifacts/comparison_results.json
@@ -161,14 +170,16 @@ jobs:
     needs: [benchmark]
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: write # github-action-benchmark pushes benchmark data to the gh-pages branch
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
 
       - name: Download benchmark results
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
         with:
           name: benchmark-results
           path: artifacts
@@ -179,7 +190,7 @@ jobs:
           cat artifacts/benchmark_results.json
 
       - name: Store benchmark result
-        uses: benchmark-action/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00
+        uses: benchmark-action/github-action-benchmark@4e0b38bc48375986542b13c0d8976b7b80c60c00 # v1
         with:
           tool: 'customSmallerIsBetter'
           output-file-path: artifacts/benchmark_results.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,28 @@ on:
   pull_request:
     branches: [ main, master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
+
+# Least privilege: every CI job only needs to read the repository.
+permissions:
+  contents: read
 
 jobs:
   fmt:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly-2026-06-16
           components: rustfmt
@@ -29,15 +39,17 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -45,7 +57,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -53,7 +65,7 @@ jobs:
             ${{ runner.os }}-cargo-index-
 
       - name: Cache target directory
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target
           key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
@@ -67,15 +79,17 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -83,7 +97,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -91,7 +105,7 @@ jobs:
             ${{ runner.os }}-cargo-index-
 
       - name: Cache target directory
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target
           key: ${{ runner.os }}-target-test-${{ hashFiles('**/Cargo.lock') }}
@@ -107,15 +121,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -123,7 +139,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -131,7 +147,7 @@ jobs:
             ${{ runner.os }}-cargo-index-
 
       - name: Cache target directory
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target
           key: ${{ runner.os }}-target-integration-test-${{ hashFiles('**/Cargo.lock') }}
@@ -268,28 +284,28 @@ jobs:
 
       - name: Upload Polkadot server logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: polkadot-server-logs
           path: polkadot-server.log
 
       - name: Upload Kusama server logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: kusama-server-logs
           path: kusama-server.log
 
       - name: Upload Asset Hub Polkadot server logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: asset-hub-polkadot-server-logs
           path: asset-hub-polkadot-server.log
 
       - name: Upload Asset Hub Kusama server logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: asset-hub-kusama-server-logs
           path: asset-hub-kusama-server.log
@@ -298,16 +314,18 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@master
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         with:
           toolchain: nightly-2026-06-16
           components: clippy
 
       - name: Cache cargo registry
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -315,7 +333,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -323,7 +341,7 @@ jobs:
             ${{ runner.os }}-cargo-index-
 
       - name: Cache target directory
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: target
           key: ${{ runner.os }}-target-clippy-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Format Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -39,7 +39,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -49,7 +49,7 @@ jobs:
           toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -57,7 +57,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -65,7 +65,7 @@ jobs:
             ${{ runner.os }}-cargo-index-
 
       - name: Cache target directory
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: target
           key: ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}
@@ -79,7 +79,7 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -89,7 +89,7 @@ jobs:
           toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -97,7 +97,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -105,7 +105,7 @@ jobs:
             ${{ runner.os }}-cargo-index-
 
       - name: Cache target directory
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: target
           key: ${{ runner.os }}-target-test-${{ hashFiles('**/Cargo.lock') }}
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build]
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -131,7 +131,7 @@ jobs:
           toolchain: nightly-2026-06-16
 
       - name: Cache cargo registry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -139,7 +139,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -147,7 +147,7 @@ jobs:
             ${{ runner.os }}-cargo-index-
 
       - name: Cache target directory
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: target
           key: ${{ runner.os }}-target-integration-test-${{ hashFiles('**/Cargo.lock') }}
@@ -284,28 +284,28 @@ jobs:
 
       - name: Upload Polkadot server logs
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: polkadot-server-logs
           path: polkadot-server.log
 
       - name: Upload Kusama server logs
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: kusama-server-logs
           path: kusama-server.log
 
       - name: Upload Asset Hub Polkadot server logs
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: asset-hub-polkadot-server-logs
           path: asset-hub-polkadot-server.log
 
       - name: Upload Asset Hub Kusama server logs
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: asset-hub-kusama-server-logs
           path: asset-hub-kusama-server.log
@@ -314,7 +314,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
@@ -325,7 +325,7 @@ jobs:
           components: clippy
 
       - name: Cache cargo registry
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -333,7 +333,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache cargo index
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
@@ -341,7 +341,7 @@ jobs:
             ${{ runner.os }}-cargo-index-
 
       - name: Cache target directory
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           path: target
           key: ${{ runner.os }}-target-clippy-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,8 +13,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: most jobs only read the repo. The build job that produces
+# image provenance elevates id-token:write on its own (see build_docker).
 permissions:
-  id-token: write
   contents: read
 
 jobs:
@@ -29,31 +30,38 @@ jobs:
     steps:
       - name: Define version
         id: version
+        # Pass workflow context through env vars (not inline ${{ }} in the
+        # script) so attacker-controllable values can't be expanded as code.
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
-          export COMMIT_SHA="${{ github.sha }}"
-          export COMMIT_SHA_SHORT=${COMMIT_SHA:0:8}
-          echo "DATE_TAG=$(date -u +'%Y%m%d-%H%M%S')-${COMMIT_SHA_SHORT}" >> ${GITHUB_OUTPUT}
-          export REF_NAME="${{ github.ref_name }}"
-          export REF_SLUG=${REF_NAME//\//_}
+          COMMIT_SHA_SHORT=${COMMIT_SHA:0:8}
+          echo "DATE_TAG=$(date -u +'%Y%m%d-%H%M%S')-${COMMIT_SHA_SHORT}" >> "${GITHUB_OUTPUT}"
+          REF_SLUG=${REF_NAME//\//_}
           if [[ ${REF_SLUG} == "main" ]]
           then
-            echo "VERSION=${REF_SLUG}-${COMMIT_SHA_SHORT}" >> $GITHUB_OUTPUT
+            echo "VERSION=${REF_SLUG}-${COMMIT_SHA_SHORT}" >> "${GITHUB_OUTPUT}"
           else
-            echo "VERSION=${REF_SLUG}" >> $GITHUB_OUTPUT
+            echo "VERSION=${REF_SLUG}" >> "${GITHUB_OUTPUT}"
           fi
           # Tag `latest` only for version tag builds (refs/tags/v*), never for
           # main/branch builds, so `latest` always points at a released version.
-          if [[ "${{ github.ref_type }}" == "tag" && "${REF_NAME}" == v* ]]
+          if [[ "${REF_TYPE}" == "tag" && "${REF_NAME}" == v* ]]
           then
-            echo "IS_LATEST=true" >> $GITHUB_OUTPUT
+            echo "IS_LATEST=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "IS_LATEST=false" >> $GITHUB_OUTPUT
+            echo "IS_LATEST=false" >> "${GITHUB_OUTPUT}"
           fi
 
   build_docker:
     name: Build docker image (${{ matrix.platform }})
     needs: [set-variables]
     environment: ${{ github.event_name == 'push' && 'main_n_tags' || null }}
+    permissions:
+      contents: read # checkout
+      id-token: write # OIDC token for docker/build-push-action image provenance
     strategy:
       matrix:
         include:
@@ -67,13 +75,15 @@ jobs:
       DATE_TAG: ${{ needs.set-variables.outputs.DATE_TAG }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         if: github.event_name == 'push'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -81,7 +91,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           DOCKER_BUILD_SUMMARY: false
           DOCKER_BUILD_RECORD_UPLOAD: false
@@ -100,7 +110,7 @@ jobs:
 
       - name: Upload digest
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: digests-${{ matrix.runner }}
           path: /tmp/digests/*
@@ -119,17 +129,17 @@ jobs:
       IS_LATEST: ${{ needs.set-variables.outputs.IS_LATEST }}
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,15 +75,15 @@ jobs:
       DATE_TAG: ${{ needs.set-variables.outputs.DATE_TAG }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         if: github.event_name == 'push'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -91,7 +91,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         env:
           DOCKER_BUILD_SUMMARY: false
           DOCKER_BUILD_RECORD_UPLOAD: false
@@ -110,7 +110,7 @@ jobs:
 
       - name: Upload digest
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: digests-${{ matrix.runner }}
           path: /tmp/digests/*
@@ -129,17 +129,17 @@ jobs:
       IS_LATEST: ${{ needs.set-variables.outputs.IS_LATEST }}
     steps:
       - name: Download digests
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: building docs only needs to read the repo; the deploy job
+# elevates its own permissions below.
 permissions:
   contents: read
 
@@ -23,10 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: npm
@@ -42,7 +46,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs/dist
 
@@ -52,12 +56,12 @@ jobs:
     needs: build-docs
     runs-on: ubuntu-latest
     permissions:
-      pages: write
-      id-token: write
+      pages: write # publish the built site to GitHub Pages
+      id-token: write # OIDC token required by actions/deploy-pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Set up Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
           cache: npm
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload Pages artifact
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: docs/dist
 
@@ -64,4 +64,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -26,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: semantic-pull-request
-        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -13,6 +13,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+# Least privilege: this workflow only validates the PR title; the job below
+# grants the single scope the action needs.
+permissions:
+  contents: read
+
 jobs:
   validate-title:
     permissions:
@@ -21,6 +26,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: semantic-pull-request
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,21 +2,38 @@
 
 Steps to prepare a new release of `polkadot-rest-api`.
 
-> **Before you start - is the CI nightly stale?** Compare the pinned nightly to the latest:
->
-> ```bash
-> grep -n "toolchain: nightly-" .github/workflows/ci.yml   # the date CI pins
-> rustup check                                             # shows latest nightly (doesn't install)
-> ```
->
-> If the pin is recent, skip to step 1. If it's stale, bump it in its **own PR before the
-> release** (a newer nightly can add clippy lints - keep that churn out of the release PR). Example [PR](https://github.com/paritytech/polkadot-rest-api/pull/359).
-> Verify the bump locally, substituting the pinned date:
->
-> ```bash
-> cargo +nightly-YYYY-MM-DD fmt --all -- --check
-> cargo +nightly-YYYY-MM-DD clippy --workspace --all-features -- -D warnings
-> ```
+## Before you start
+
+Four pins are maintained by hand — Dependabot doesn't bump them. Check each; if stale, bump it in
+its **own PR before the release**.
+
+**1. CI nightly toolchain** (`ci.yml`) — a newer nightly can add clippy lints.
+```bash
+grep -n "toolchain: nightly-" .github/workflows/ci.yml   # pinned
+rustup check                                             # latest
+```
+If stale, bump the date and verify: `cargo +nightly-YYYY-MM-DD fmt --all -- --check` and `... clippy --workspace --all-features -- -D warnings`. Example: [#359](https://github.com/paritytech/polkadot-rest-api/pull/359).
+
+**2. `dtolnay/rust-toolchain` action** (`ci.yml`, `# master`) — no release tag, so Dependabot skips it.
+```bash
+pinned=$(grep -m1 -oE 'rust-toolchain@[0-9a-f]{40}' .github/workflows/ci.yml | cut -d@ -f2)
+git ls-remote https://github.com/dtolnay/rust-toolchain master | grep -q "$pinned" && echo "UP TO DATE" || echo "BEHIND"
+```
+If `BEHIND`, replace the SHA in **all** `ci.yml` occurrences (keep `# master`).
+
+**3. `ubuntu:22.04` container digest** (`benchmark.yml`) — a container image, not an action.
+```bash
+grep -n "ubuntu:22.04@sha256" .github/workflows/benchmark.yml    # pinned
+docker buildx imagetools inspect ubuntu:22.04 | grep -i digest   # latest (needs Docker)
+```
+If different, update the `@sha256:...` in `benchmark.yml`.
+
+**4. Build Rust version** (`Dockerfile`, `rust:X.Y.Z-...`) — no `docker` Dependabot ecosystem set up.
+```bash
+grep -n "FROM.*rust:" Dockerfile   # pinned build Rust
+rustup check                       # latest stable
+```
+If behind, bump the version in the `Dockerfile` `FROM` line.
 
 ## 1. Bump workspace version
 


### PR DESCRIPTION
Closes: #365

### Description

This PR fixes the GitHub Actions security findings reported by zizmor (issue #365). It hardens the 5 workflow files and does not change what any workflow does. All 74 actionable findings are resolved (verified locally with `zizmor@1.26.1 --min-severity low --persona pedantic` -> "No findings to report").

Main changes:

- Pin every action to a commit SHA (and the ubuntu container to a digest) so a moved tag cannot swap the code we run, each with an exact `# vX.Y.Z` version comment.
- Add least-privilege `permissions:` blocks so workflows do not run with a broad token.
- Fix a script-injection risk in the deploy workflow.
- Stop checkout from leaving credentials in the workspace.
- Add a Dependabot config so the newly pinned actions stay up to date automatically.
- Document the pins Dependabot can't auto-bump (`dtolnay/rust-toolchain@master`, the `ubuntu:22.04` container digest, the Dockerfile build Rust version, and the CI nightly) as quick pre-release checks in `RELEASE.md`.

### Changes per file

- `ci.yml`: SHA-pin actions, top-level read-only `permissions`, `concurrency` group, `persist-credentials: false`.
- `benchmark.yml`: SHA-pin actions + `ubuntu:22.04` container digest, least-privilege `permissions`, `persist-credentials: false`.
- `deploy.yml`: SHA-pin actions, `github.*` via `env` (no script injection), `id-token: write` scoped to the build job, `persist-credentials: false`.
- `docs.yml`: SHA-pin actions, `persist-credentials: false`.
- `semantic.yml`: SHA-pin the action, top-level read-only `permissions`.
- `dependabot.yml` (new): weekly grouped `github-actions` version updates so pins don't go stale (separate from the existing settings-based npm/cargo security updates).
- Review follow-up: exact `# vX.Y.Z` comments on every SHA pin (verified via GitHub tags API); `rust-toolchain` stays `# master` (branch pin, no tag).
- `RELEASE.md`: **Before you start** section — checks for the four hand-maintained pins Dependabot doesn't bump.

### How to verify

```bash
cd polkadot-rest-api
docker run --rm -v ./:/polkadot-rest-api ghcr.io/astral-sh/uv:debian \
  sh -c "cd /polkadot-rest-api && uvx zizmor@1.26.1 --min-severity low --persona pedantic ."
```

Expected: `No findings to report. Good job! (7 ignored)`
