### PR TITLE
docs: add Claude Code skills for chain-data decoding

### DIFF
--- a/.claude/skills/prefer-subxt-over-rpc/SKILL.md
+++ b/.claude/skills/prefer-subxt-over-rpc/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: prefer-subxt-over-rpc
+description: Use when fetching or decoding chain data (blocks, extrinsics, events, storage, runtime APIs) and tempted to make manual RPC calls (legacy_rpc, rpc_params!, chain_getBlock, state_call), or when writing code that branches on metadata versions
+---
+
+# Prefer Subxt over manual RPC
+
+## Overview
+
+Subxt 0.50 covers ~99% of chain access — fetching and decoding blocks, extrinsics, events, storage, constants, runtime APIs and view functions — across **all runtime versions back to genesis**. Manual RPC (`legacy_rpc`, `rpc_params!`) is a last resort, not a default.
+
+## Quick reference
+
+| Task | Instead of RPC, use |
+|------|---------------------|
+| Latest finalized block | `api.at_current_block().await?` |
+| Specific block | `api.at_block(...).await?` |
+| Storage read (one-shot) | `at_block.storage().fetch(addr, keys)` / `.iter(...)` |
+| Storage read (reusable handle) | `at_block.storage().entry(addr)?` then `.fetch(keys)` |
+| Storage read that may be absent | `at_block.storage().try_fetch(addr, keys)` (returns `Option`) |
+| Events | `at_block.events()` |
+| Extrinsics | `at_block.extrinsics()` |
+| Runtime API call | `at_block.runtime_apis()` |
+| View functions | `at_block.view_functions()` |
+| Constants | `at_block.constants()` |
+| Metadata / spec version | `at_block.metadata()`, `at_block.spec_version()` |
+
+End-to-end example — a dynamic storage read at a block, no RPC anywhere:
+
+```rust
+let at_block = api.at_block(block_hash).await?;
+let addr = subxt::dynamic::storage::<(), u32>("Referenda", "ReferendumCount");
+let count: u32 = at_block.storage().fetch(addr, ()).await?.decode()?;
+```
+
+Keyed entries take the keys as a tuple in `fetch` (e.g. `.fetch(addr, (account_id,))`). Both `fetch` and `entry` accept dynamic and static/codegen addresses alike — `fetch(addr, keys)` is just shorthand for `entry(addr)?.fetch(keys)`, so choose by whether you reuse the handle, not by address kind. Note `fetch` **errors** with `NoValueFound` when a map entry has no value and no default; for entries that may be absent (common on account/map reads) use `try_fetch`, which returns `Option`. See the `scale-decoding` skill for choosing the value type parameter.
+
+## Metadata versions: don't hand-roll (for chain data)
+
+When **reading chain data** (storage, events, extrinsics, runtime APIs), don't branch on metadata versions yourself. Subxt already converts **every historic and modern metadata format** into `subxt::Metadata`, and has usually already downloaded it for the block you're working at.
+
+Pre-V14 blocks additionally need legacy type info:
+- `PolkadotConfig` ships Polkadot relay chain historic types **by default** (opt out with `PolkadotConfig::builder().use_historic_types(false).build()`).
+- `SubstrateConfig` needs them provided: `SubstrateConfig::builder().set_legacy_types(registry).build()` (a `scale_info_legacy::ChainTypeRegistry`). This repo uses `SubstrateConfig`, and that wiring already lives in `build_subxt_config` (`crates/server/src/state.rs`), keyed by the chain-config `legacy_types` string — add a case there rather than building configs inline.
+
+For chain-data access, if `subxt::Metadata` doesn't expose something you need, file a subxt PR to expose it rather than decoding raw metadata.
+
+**Exception:** endpoints that serve version-faithful raw metadata JSON (e.g. `handlers/runtime/get_metadata.rs`, which emits distinct `v14`/`v15` shapes) legitimately decode `frame_metadata::RuntimeMetadata` and branch on its version — normalized `subxt::Metadata` can't reproduce those shapes. That branching is expected there; don't "fix" it away.
+
+## Notes
+
+- No runtime-upgrade monitoring is needed — subxt resolves the correct metadata/spec version per block automatically. Mind the cost, though: with the default config (this repo sets no spec-version ranges), each `at_block` issues an extra `Core_version` RPC to resolve the spec version — converted metadata is cached per spec version, but that resolution is not cached per block. On hot paths, pre-seed with `set_spec_version_for_block_ranges` / `set_metadata_for_spec_versions` to drop the round-trips.
+- The subxt pin lives in `crates/server/Cargo.toml` (likewise `frame-decode` and its `legacy-types` feature). Before relying on version-specific behavior, check that pin against the subxt CHANGELOG — e.g. `SubstrateConfigBuilder::set_genesis_hash` was a no-op until 0.50.2. The `VerifySignature` extension-identifier rename is covered in the `v5-extrinsic-signatures` skill.

--- a/.claude/skills/scale-decoding/SKILL.md
+++ b/.claude/skills/scale-decoding/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: scale-decoding
+description: Use when decoding SCALE bytes, defining value types for dynamic storage queries, or choosing between parity_scale_codec::Decode and scale_decode::DecodeAsType — including when decoded values look subtly wrong without any error
+---
+
+# SCALE decoding practices
+
+## Storage query typing
+
+```rust
+let addr = subxt::dynamic::storage::<(), u32>("Referenda", "ReferendumCount");
+let value = at_block.storage().fetch(addr, ()).await?; // second fetch arg = key tuple; () for plain entries
+let count: u32 = value.decode()?;
+```
+
+The second type parameter on the address is the value type `.decode()` will produce:
+
+- Not going to call `.decode()`? Use `()` to say so.
+- Have your own type? Derive `scale_decode::DecodeAsType` on it and use it there, or call `.decode_as::<MyType>()` on the fetched value to decode into an arbitrary `DecodeAsType` type.
+- Prefer concrete types over `scale_value::Value` where the shape is known — `Value` is for genuinely dynamic data.
+
+## Decode vs DecodeAsType
+
+| | `parity_scale_codec::Decode` | `scale_decode::DecodeAsType` |
+|---|---|---|
+| Speed | very fast | slightly slower |
+| Type info | none needed | required (from metadata) |
+| Layout mismatch | silently produces wrong data | a genuine mismatch errors; only *compatible* differences are absorbed (skips fields you don't read, widens e.g. u8→u32, unwraps newtypes) |
+| Failure mode | can "succeed" with garbage | errors — or exposes missing type info (report upstream so it gets fixed) |
+
+**Default to `DecodeAsType` for chain data** — its layout varies across runtimes. Raw `Decode` is fine for types whose encoding you fully control, and also for deliberate hot-path decodes of stable chain types (e.g. `Era`, fee `RuntimeDispatchInfo`) where the metadata-driven path is too slow — several exist in this repo by design, so don't migrate them without a reason.
+
+## Leftover bytes = something went wrong
+
+With `Decode`, leftover bytes after decoding (almost always) mean your target type doesn't match the encoded bytes — and plain `decode()` won't tell you. Use `DecodeAll` instead, which errors on trailing bytes:
+
+```rust
+use parity_scale_codec::DecodeAll;
+let val = MyType::decode_all(&mut &bytes[..])?;
+```
+
+(In rare cases leftover bytes mean the on-chain storage itself is corrupt — still worth surfacing, never worth ignoring.)
+
+The two fixes above are complementary, not alternatives: prefer `DecodeAsType` wherever metadata type info exists; on paths where raw `Decode` must stay, swap plain `decode()` for `decode_all()` **only when you decode a whole buffer**. Do not use `decode_all` for cursor parsing — code that decodes one field from `&mut &bytes[..]` and advances through a larger buffer (e.g. the era/signature parsing in `utils/extrinsic.rs`) leaves trailing bytes on purpose, and `decode_all` would reject them.

--- a/.claude/skills/v5-extrinsic-signatures/SKILL.md
+++ b/.claude/skills/v5-extrinsic-signatures/SKILL.md
@@ -1,0 +1,56 @@
+---
+name: v5-extrinsic-signatures
+description: Use when extrinsics unexpectedly report is_signed() == false or a missing signature, or when handling V5 "General" extrinsics/transactions
+---
+
+# V5 extrinsic signatures live in transaction extensions
+
+## Overview
+
+Subxt decodes V5 extrinsics fine, but V5 General transactions **appear unsigned**: `extrinsic.signature_bytes() == None` and `extrinsic.is_signed() == false`. This is not a bug — the signature moved into the transaction extensions.
+
+## Finding the signature
+
+Look for the `VerifySignature` transaction extension:
+
+```rust
+use subxt::config::transaction_extensions::VerifySignature;
+
+let details = extrinsic
+    .transaction_extensions()
+    .and_then(|exts| exts.find::<VerifySignature<_>>()) // config is inferred from the extrinsic
+    .transpose()?; // find returns Option<Result<_>>: Some(Err(_)) = matched but undecodable, None = no match
+// details: Option<VerifySignatureDetails> — Disabled, or Signed { signature, account }
+```
+
+In this repo the client is `SubstrateConfig` (`crates/server/src/state.rs`), so leave the config as `VerifySignature<_>` and let it infer — a hardcoded `VerifySignature<PolkadotConfig>` won't satisfy `find`'s bound. Put the lookup alongside the other shared extension types in `crates/server/src/utils/transaction_extensions.rs` rather than hand-rolling it per handler.
+
+## Version landmine
+
+The on-chain identifier the extension matches against changed:
+
+| subxt version | identifier matched |
+|---|---|
+| `< 0.50.1` (the beta.4 in `crates/server/Cargo.toml`) | `"VerifySignature"` |
+| `0.50.1+` | `"VerifyMultiSignature"` (rename, subxt#2197) |
+
+The Rust type is unchanged — you keep writing `find::<VerifySignature<_>>()` on both sides of the bump. What changed is the extension **name in chain metadata** that the lookup matches: `< 0.50.1` only finds runtimes calling it `VerifySignature`; `0.50.1+` only finds runtimes calling it `VerifyMultiSignature`. A `find` name mismatch silently returns `None`.
+
+You don't have to change subxt versions to fix it — match either name yourself:
+
+```rust
+let sig = match extrinsic.transaction_extensions() {
+    Some(exts) => exts
+        .iter()
+        .find(|ext| matches!(ext.name(), "VerifySignature" | "VerifyMultiSignature"))
+        .map(|ext| ext.decode_unchecked_as::<VerifySignatureDetails<SubstrateConfig>>())
+        .transpose()?,
+    None => None,
+};
+```
+
+`decode_unchecked_as` skips the name check that `find` enforces, so one path handles both identifiers. Unlike `find` (which infers the config from the extrinsic), `decode_unchecked_as` can't infer it — name the config explicitly (`SubstrateConfig` in this repo).
+
+## Caveat
+
+Chains can opt to use different extensions or handle signatures in arbitrary ways under V5 — don't assume `VerifySignature` is universal across chains.


### PR DESCRIPTION
### Description

- Adds three Claude Code skills under `.claude/skills/`. Each is a short markdown guide that tells Claude how to work with chain data in this repo, pinned to the current `subxt 0.50.0-beta.4`.

### Files

- `.claude/skills/prefer-subxt-over-rpc/SKILL.md`: tells Claude to use subxt's high-level API (blocks, storage, events, runtime APIs) instead of manual RPC calls, and to let subxt pick the right metadata per block instead of branching on metadata versions by hand.

- `.claude/skills/scale-decoding/SKILL.md`: explains how to type dynamic storage queries and when to use `DecodeAsType` (safe, metadata-driven) versus raw `Decode` (fast, no type check), and warns that leftover bytes usually mean the wrong type.

- `.claude/skills/v5-extrinsic-signatures/SKILL.md`: explains that V5 "General" extrinsics look unsigned because the signature moved into the transaction extensions, and shows how to read it from the `VerifySignature` extension.

