### PR TITLE
fix: surface validator self-stake incentive in staking-payouts

### DIFF
--- a/crates/server/src/handlers/accounts/get_staking_payouts.rs
+++ b/crates/server/src/handlers/accounts/get_staking_payouts.rs
@@ -2,14 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::types::{
-    AccountsError, BlockInfo, EraPayouts, EraPayoutsData, StakingPayoutsQueryParams,
-    StakingPayoutsResponse, ValidatorPayout,
+    AccountsError, BlockInfo, EraPayouts, StakingPayoutsQueryParams, StakingPayoutsResponse,
 };
 use super::utils::validate_and_parse_address;
 use crate::consts::get_migration_boundaries;
 use crate::extractors::JsonQuery;
 use crate::handlers::common::accounts::{
-    RawEraPayouts, RawStakingPayouts, StakingPayoutsParams, query_staking_payouts,
+    RawStakingPayouts, StakingPayoutsParams, query_staking_payouts,
 };
 use crate::state::AppState;
 use crate::utils::{self, fetch_block_timestamp, find_ah_blocks_in_rc_block};
@@ -125,33 +124,7 @@ fn format_response(
     rc_block_number: Option<String>,
     ah_timestamp: Option<String>,
 ) -> StakingPayoutsResponse {
-    let eras_payouts = raw
-        .eras_payouts
-        .iter()
-        .map(|era_payout| match era_payout {
-            RawEraPayouts::Payouts(data) => EraPayouts::Payouts(EraPayoutsData {
-                era: data.era.to_string(),
-                total_era_reward_points: data.total_era_reward_points.to_string(),
-                total_era_payout: data.total_era_payout.to_string(),
-                payouts: data
-                    .payouts
-                    .iter()
-                    .map(|p| ValidatorPayout {
-                        validator_id: p.validator_id.clone(),
-                        nominator_staking_payout: p.nominator_staking_payout.to_string(),
-                        claimed: p.claimed,
-                        total_validator_reward_points: p.total_validator_reward_points.to_string(),
-                        validator_commission: p.validator_commission.to_string(),
-                        total_validator_exposure: p.total_validator_exposure.to_string(),
-                        nominator_exposure: p.nominator_exposure.to_string(),
-                    })
-                    .collect(),
-            }),
-            RawEraPayouts::Message { message } => EraPayouts::Message {
-                message: message.clone(),
-            },
-        })
-        .collect();
+    let eras_payouts = raw.eras_payouts.iter().map(EraPayouts::from).collect();
 
     StakingPayoutsResponse {
         at: BlockInfo {

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -4,7 +4,7 @@
 //! Types for account-related handlers.
 
 use super::utils::AddressValidationError;
-use crate::handlers::common::accounts::StakingPayoutsQueryError;
+use crate::handlers::common::accounts::{RawEraPayouts, StakingPayoutsQueryError};
 use crate::state::RelayChainError;
 use crate::utils::{self, RcBlockError};
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -938,8 +938,12 @@ pub struct EraPayoutsData {
     /// Total reward points for the era
     pub total_era_reward_points: String,
 
-    /// Total payout for the era
+    /// Total payout for the era (staker-reward pool only)
     pub total_era_payout: String,
+
+    /// Era-wide validator self-stake incentive pot for the era. "0" on non-DAP chains.
+    /// Add to `totalEraPayout` for the full validator era payout (matches `EraPaid.validator_payout`).
+    pub total_era_self_stake_incentive_payout: String,
 
     /// Individual payouts for validators nominated
     pub payouts: Vec<ValidatorPayout>,
@@ -969,6 +973,51 @@ pub struct ValidatorPayout {
 
     /// Nominator's stake behind this validator
     pub nominator_exposure: String,
+
+    /// This validator's total self-stake incentive for the era. "0" on non-DAP chains.
+    /// A validator-only reward: it is populated on every entry (informational for nominators) but
+    /// is only income for the account when `validatorId == accountId`, so do NOT sum it across
+    /// entries. When the queried account is this validator, add it to `nominatorStakingPayout` for
+    /// the validator's true era income.
+    pub validator_self_stake_incentive: String,
+}
+
+/// Maps the transport-agnostic `RawEraPayouts` (from the `common` query layer) into the HTTP
+/// response shape. Lives here — beside the response types it builds — and is shared by both the
+/// standard and RC staking-payouts handlers, keeping the balance-to-string mapping in one place
+/// without the `common` layer having to depend on these response types.
+impl From<&RawEraPayouts> for EraPayouts {
+    fn from(raw: &RawEraPayouts) -> Self {
+        match raw {
+            RawEraPayouts::Payouts(data) => EraPayouts::Payouts(EraPayoutsData {
+                era: data.era.to_string(),
+                total_era_reward_points: data.total_era_reward_points.to_string(),
+                total_era_payout: data.total_era_payout.to_string(),
+                total_era_self_stake_incentive_payout: data
+                    .total_era_self_stake_incentive_payout
+                    .to_string(),
+                payouts: data
+                    .payouts
+                    .iter()
+                    .map(|p| ValidatorPayout {
+                        validator_id: p.validator_id.clone(),
+                        nominator_staking_payout: p.nominator_staking_payout.to_string(),
+                        claimed: p.claimed,
+                        total_validator_reward_points: p.total_validator_reward_points.to_string(),
+                        validator_commission: p.validator_commission.to_string(),
+                        total_validator_exposure: p.total_validator_exposure.to_string(),
+                        nominator_exposure: p.nominator_exposure.to_string(),
+                        validator_self_stake_incentive: p
+                            .validator_self_stake_incentive
+                            .to_string(),
+                    })
+                    .collect(),
+            }),
+            RawEraPayouts::Message { message } => EraPayouts::Message {
+                message: message.clone(),
+            },
+        }
+    }
 }
 
 // ================================================================================================

--- a/crates/server/src/handlers/common/accounts/staking_payouts.rs
+++ b/crates/server/src/handlers/common/accounts/staking_payouts.rs
@@ -7,6 +7,7 @@ use crate::consts::{get_chain_display_name, get_migration_boundaries, is_bad_sta
 use crate::handlers::runtime_queries::staking;
 use crate::utils::ResolvedBlock;
 use sp_core::crypto::{AccountId32, Ss58Codec};
+use sp_runtime::Perbill;
 use subxt::{OnlineClientAtBlock, SubstrateConfig};
 use thiserror::Error;
 
@@ -117,8 +118,11 @@ pub struct RawEraPayoutsData {
     pub era: u32,
     /// Total reward points for the era
     pub total_era_reward_points: u32,
-    /// Total payout for the era
+    /// Total payout for the era (staker-reward pool only; `Staking.ErasValidatorReward`)
     pub total_era_payout: u128,
+    /// Era-wide validator self-stake incentive pot (`Staking.ErasValidatorIncentiveBudget`).
+    /// `0` on chains without `pallet_staking_async` (legacy/relay staking).
+    pub total_era_self_stake_incentive_payout: u128,
     /// Individual payouts for validators nominated
     pub payouts: Vec<RawValidatorPayout>,
 }
@@ -140,6 +144,9 @@ pub struct RawValidatorPayout {
     pub total_validator_exposure: u128,
     /// Nominator's stake behind this validator
     pub nominator_exposure: u128,
+    /// This validator's total self-stake incentive for the era (`share × budget`).
+    /// A validator-only reward; `0` on chains without `pallet_staking_async`.
+    pub validator_self_stake_incentive: u128,
 }
 
 // ================================================================================================
@@ -325,6 +332,11 @@ async fn fetch_era_data(
         }
     };
 
+    // Build the era-level self-stake incentive context ONCE (DAP chains only; `None` otherwise).
+    // The metadata gate inside means legacy/relay chains issue no extra RPC, and every validator
+    // in this era shares the same budget/denominator/flag instead of re-reading them per validator.
+    let incentive_ctx = staking::get_era_incentive_context(client_at_block, era).await;
+
     // Get exposure data using targeted approach (current nominations)
     let exposure_data =
         fetch_exposure_data(client_at_block, account, era, &account_bytes, ss58_prefix).await?;
@@ -338,6 +350,7 @@ async fn fetch_era_data(
         &individual_points,
         total_era_reward_points,
         total_era_payout,
+        incentive_ctx.as_ref(),
         unclaimed_only,
     )
     .await?;
@@ -357,6 +370,7 @@ async fn fetch_era_data(
                 &individual_points,
                 total_era_reward_points,
                 total_era_payout,
+                incentive_ctx.as_ref(),
                 unclaimed_only,
             )
             .await?;
@@ -371,6 +385,8 @@ async fn fetch_era_data(
         era,
         total_era_reward_points,
         total_era_payout,
+        // Era-wide incentive pot: the context's budget, or 0 when there is no incentive.
+        total_era_self_stake_incentive_payout: incentive_ctx.map_or(0, |ctx| ctx.budget),
         payouts,
     }))
 }
@@ -392,6 +408,7 @@ async fn build_payouts(
     individual_points: &std::collections::HashMap<[u8; 32], u32>,
     total_era_reward_points: u32,
     total_era_payout: u128,
+    incentive_ctx: Option<&staking::EraIncentiveContext>,
     unclaimed_only: bool,
 ) -> Result<Vec<RawValidatorPayout>, String> {
     let mut payouts = Vec::new();
@@ -434,6 +451,23 @@ async fn build_payouts(
             is_validator,
         );
 
+        // This validator's self-stake incentive for the era (DAP chains; 0 otherwise). Only the
+        // per-validator weight is read here; the era-level budget/denominator/flag come from the
+        // shared context fetched once in `fetch_era_data`.
+        let validator_self_stake_incentive = match incentive_ctx {
+            Some(ctx) => {
+                let weight = staking::get_validator_incentive_weight(
+                    client_at_block,
+                    era,
+                    &validator_bytes_arr,
+                )
+                .await;
+                let numerator = incentive_numerator(ctx.weighted, weight, validator_points);
+                incentive_from_ratio(ctx.budget, numerator, ctx.denominator)
+            }
+            None => 0,
+        };
+
         payouts.push(RawValidatorPayout {
             validator_id: validator_id.clone(),
             nominator_staking_payout: nominator_payout,
@@ -442,6 +476,7 @@ async fn build_payouts(
             validator_commission: commission,
             total_validator_exposure: *total_exposure,
             nominator_exposure: *nominator_exposure,
+            validator_self_stake_incentive,
         });
     }
 
@@ -679,4 +714,105 @@ fn calculate_payout(
     }
 }
 
+// ================================================================================================
+// Self-stake incentive (DAP / pallet_staking_async)
+// ================================================================================================
+
+/// Select the incentive-share numerator for the era's formula (pure).
+///
+/// Mirrors `pallet_staking_async`: weighted-points eras use `weight × validator_points`; legacy
+/// eras use `weight` alone (points are ignored).
+///
+/// INVARIANT: this branch MUST stay in lockstep with the denominator source picked in
+/// `staking::get_era_incentive_context` (both key off the same `weighted` flag). Weighted numerator
+/// ↔ `ErasSumWeightedPoints`; legacy numerator ↔ `ErasSumValidatorIncentiveWeight`.
+fn incentive_numerator(
+    weighted: bool,
+    validator_incentive_weight: u128,
+    validator_points: u32,
+) -> u128 {
+    if weighted {
+        validator_incentive_weight.saturating_mul(validator_points as u128)
+    } else {
+        validator_incentive_weight
+    }
+}
+
+/// Compute a validator's total self-stake incentive as `floor(share × budget)`, where
+/// `share = numerator / denominator` (pure).
+///
+/// Uses `Perbill` to match the pallet's fixed-point rounding (`from_rational` + `mul_floor`, see
+/// `calculate_validator_incentive_for_page`). This is the pre-page total (`share × budget`): the
+/// pallet floors each exposure page independently, so for a multi-page validator the sum actually
+/// minted is up to `(pages − 1)` planck less than this — sub-nano-DOT accounting dust. Returns `0`
+/// on any zero input (a zero denominator is the pallet's storage-inconsistency guard).
+fn incentive_from_ratio(budget: u128, numerator: u128, denominator: u128) -> u128 {
+    if budget == 0 || numerator == 0 || denominator == 0 {
+        return 0;
+    }
+    Perbill::from_rational(numerator, denominator).mul_floor(budget)
+}
+
 // Decoding functions have been moved to runtime_queries::staking module
+
+#[cfg(test)]
+mod tests {
+    use super::{incentive_from_ratio, incentive_numerator};
+
+    // --- numerator selection (pins the weighted vs legacy branch wiring) ---
+
+    // weighted era: numerator = weight × validator_points
+    #[test]
+    fn numerator_weighted_uses_weight_times_points() {
+        assert_eq!(incentive_numerator(true, 2, 3), 6);
+    }
+
+    // legacy era: numerator = weight; validator_points are IGNORED
+    #[test]
+    fn numerator_legacy_ignores_points() {
+        assert_eq!(incentive_numerator(false, 2, 999), 2);
+    }
+
+    // --- ratio → floor(share × budget) ---
+
+    #[test]
+    fn ratio_zero_inputs_are_zero() {
+        assert_eq!(incentive_from_ratio(0, 5, 30), 0); // zero budget
+        assert_eq!(incentive_from_ratio(300, 0, 30), 0); // zero numerator (e.g. zero weight)
+        assert_eq!(incentive_from_ratio(300, 5, 0), 0); // zero denominator (inconsistency guard)
+    }
+
+    // share = 6/12 = 1/2 (exactly representable in ppb); 1/2 of 300 = 150
+    #[test]
+    fn ratio_half_of_budget() {
+        assert_eq!(incentive_from_ratio(300, 6, 12), 150);
+    }
+
+    // whole pot when this validator is the only contributor
+    #[test]
+    fn ratio_full_share_takes_whole_budget() {
+        assert_eq!(incentive_from_ratio(300, 10, 10), 300);
+    }
+
+    // floor rounding matches the pallet: 1/3 of 100 = 33 (not 34)
+    #[test]
+    fn ratio_floors_like_the_pallet() {
+        assert_eq!(incentive_from_ratio(100, 1, 3), 33);
+    }
+
+    // --- end-to-end wiring: numerator selection composed with the ratio ---
+
+    // weighted: weight=2 points=3 → numerator 6, denom 12 → 1/2 → 150
+    #[test]
+    fn weighted_end_to_end() {
+        let numerator = incentive_numerator(true, 2, 3);
+        assert_eq!(incentive_from_ratio(300, numerator, 12), 150);
+    }
+
+    // legacy: weight=1 (points ignored) → numerator 1, denom 2 → 1/2 → 150
+    #[test]
+    fn legacy_end_to_end() {
+        let numerator = incentive_numerator(false, 1, 999);
+        assert_eq!(incentive_from_ratio(300, numerator, 2), 150);
+    }
+}

--- a/crates/server/src/handlers/rc/accounts/get_staking_payouts.rs
+++ b/crates/server/src/handlers/rc/accounts/get_staking_payouts.rs
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 use super::types::{
-    AccountsError, BlockInfo, EraPayouts, EraPayoutsData, RcStakingPayoutsQueryParams,
-    RcStakingPayoutsResponse, RelayChainAccess, ValidatorPayout,
+    AccountsError, BlockInfo, EraPayouts, RcStakingPayoutsQueryParams, RcStakingPayoutsResponse,
+    RelayChainAccess,
 };
 use crate::extractors::JsonQuery;
 use crate::handlers::accounts::utils::validate_and_parse_address;
 use crate::handlers::common::accounts::{
-    RawEraPayouts, RawStakingPayouts, StakingPayoutsParams, query_staking_payouts,
+    RawStakingPayouts, StakingPayoutsParams, query_staking_payouts,
 };
 use crate::state::AppState;
 use crate::utils;
@@ -155,33 +155,7 @@ async fn get_relay_chain_access(state: &AppState) -> Result<RelayChainAccess, Ac
 // ================================================================================================
 
 fn format_response(raw: &RawStakingPayouts) -> RcStakingPayoutsResponse {
-    let eras_payouts = raw
-        .eras_payouts
-        .iter()
-        .map(|era_payout| match era_payout {
-            RawEraPayouts::Payouts(data) => EraPayouts::Payouts(EraPayoutsData {
-                era: data.era.to_string(),
-                total_era_reward_points: data.total_era_reward_points.to_string(),
-                total_era_payout: data.total_era_payout.to_string(),
-                payouts: data
-                    .payouts
-                    .iter()
-                    .map(|p| ValidatorPayout {
-                        validator_id: p.validator_id.clone(),
-                        nominator_staking_payout: p.nominator_staking_payout.to_string(),
-                        claimed: p.claimed,
-                        total_validator_reward_points: p.total_validator_reward_points.to_string(),
-                        validator_commission: p.validator_commission.to_string(),
-                        total_validator_exposure: p.total_validator_exposure.to_string(),
-                        nominator_exposure: p.nominator_exposure.to_string(),
-                    })
-                    .collect(),
-            }),
-            RawEraPayouts::Message { message } => EraPayouts::Message {
-                message: message.clone(),
-            },
-        })
-        .collect();
+    let eras_payouts = raw.eras_payouts.iter().map(EraPayouts::from).collect();
 
     RcStakingPayoutsResponse {
         at: BlockInfo {

--- a/crates/server/src/handlers/runtime_queries/staking.rs
+++ b/crates/server/src/handlers/runtime_queries/staking.rs
@@ -806,27 +806,55 @@ pub async fn get_era_incentive_context(
         return None;
     }
 
-    // Budget and the weighted-points flag are independent reads — fetch them concurrently.
-    let (budget, weighted) = tokio::join!(
+    // Budget, the weighted-points flag, and BOTH candidate denominators are independent reads —
+    // fetch them concurrently. We read both sums (not just the flag's pick) so we can reconcile the
+    // flag against what is actually maintained on-chain; see the branch-selection note below.
+    let (budget, flag_weighted, weighted_sum, legacy_sum) = tokio::join!(
         fetch_era_u128(client_at_block, "ErasValidatorIncentiveBudget", era),
         uses_weighted_points(client_at_block, era),
+        fetch_era_u128(client_at_block, "ErasSumWeightedPoints", era),
+        fetch_era_u128(client_at_block, "ErasSumValidatorIncentiveWeight", era),
     );
     if budget == 0 {
         return None;
     }
 
-    // Denominator source MUST match the numerator basis chosen by `incentive_numerator`.
-    let denominator = if weighted {
-        fetch_era_u128(client_at_block, "ErasSumWeightedPoints", era).await
-    } else {
-        fetch_era_u128(client_at_block, "ErasSumValidatorIncentiveWeight", era).await
-    };
+    // Reconcile the pallet's intent flag against the denominators actually maintained on-chain.
+    let (weighted, denominator) = resolve_incentive_basis(flag_weighted, weighted_sum, legacy_sum)?;
 
     Some(EraIncentiveContext {
         budget,
         denominator,
         weighted,
     })
+}
+
+/// Resolve which incentive-share basis (weighted-points vs legacy stake-only) an era actually uses,
+/// returning `(weighted, denominator)` — or `None` when no basis is maintained (caller pays `0`).
+///
+/// The `uses_weighted_points` flag is the pallet's *intent*, but on a chain where
+/// `WeightedPointsFormulaStartEra` is unset the flag defaults to "weighted" for pre-cutoff eras
+/// whose `ErasSumWeightedPoints` denominator was never maintained (see the pallet's own doc:
+/// pre-cutoff eras "may have reward points credited before their ErasSumWeightedPoints denominator
+/// was maintained"). Trusting the flag there divides by an empty sum and pays `0`. So we take the
+/// weighted branch only when the flag says weighted AND its denominator is actually populated;
+/// otherwise we fall back to the legacy stake-only sum, which is what such eras were paid on.
+///
+/// The returned `weighted` bool MUST be the one threaded into `incentive_numerator`, so the
+/// numerator basis and this denominator always agree. Pure — unit-tested below.
+fn resolve_incentive_basis(
+    flag_weighted: bool,
+    weighted_sum: u128,
+    legacy_sum: u128,
+) -> Option<(bool, u128)> {
+    if flag_weighted && weighted_sum != 0 {
+        Some((true, weighted_sum))
+    } else if legacy_sum != 0 {
+        Some((false, legacy_sum))
+    } else {
+        // Neither denominator is populated: no maintained basis for this era → no incentive.
+        None
+    }
 }
 
 /// Get a validator's per-era incentive weight from `Staking.ErasValidatorIncentiveWeight`
@@ -870,12 +898,15 @@ async fn fetch_era_u128(
     0
 }
 
-/// Whether an era uses the weighted-points incentive formula.
+/// The pallet's *intended* weighted-points flag for an era (before reconciling against which
+/// denominator is actually maintained on-chain — see `get_era_incentive_context`).
 ///
 /// Mirrors `pallet_staking_async`'s `uses_weighted_points`: reads
 /// `Staking.WeightedPointsFormulaStartEra` (`StorageValue<EraIndex, OptionQuery>`). `None` (unset,
 /// or item absent) means "weighted"; otherwise the era is weighted iff `era >= start` — exactly
-/// the pallet's `map_or(true, |start| era >= start)`.
+/// the pallet's `map_or(true, |start| era >= start)`. NOTE: this default can over-report "weighted"
+/// for pre-cutoff eras on chains where the cutoff was never recorded, which is why the caller
+/// cross-checks it against a non-empty `ErasSumWeightedPoints` before trusting it.
 async fn uses_weighted_points(
     client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
     era: u32,
@@ -1831,4 +1862,41 @@ pub async fn iter_unapplied_slashes(
     }
 
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_incentive_basis;
+
+    // Flag says weighted and the weighted denominator is populated: take the weighted branch.
+    #[test]
+    fn basis_weighted_when_flag_and_weighted_sum_present() {
+        assert_eq!(resolve_incentive_basis(true, 500, 999), Some((true, 500)));
+    }
+
+    // Flag says legacy: use the legacy sum even if a (stale) weighted sum happens to be non-zero.
+    #[test]
+    fn basis_legacy_when_flag_not_weighted() {
+        assert_eq!(resolve_incentive_basis(false, 500, 999), Some((false, 999)));
+    }
+
+    // THE REGRESSION CASE (live era 2222): `WeightedPointsFormulaStartEra` unset → flag defaults to
+    // weighted, but `ErasSumWeightedPoints` was never maintained (0). Trusting the flag would divide
+    // by 0 and pay nothing; we must fall back to the populated legacy sum instead.
+    #[test]
+    fn basis_falls_back_to_legacy_when_weighted_sum_empty() {
+        assert_eq!(
+            resolve_incentive_basis(true, 0, 8_325_927_145),
+            Some((false, 8_325_927_145)),
+            "flag-weighted but empty weighted sum must fall back to the legacy denominator"
+        );
+    }
+
+    // Flag weighted, weighted sum empty, AND legacy sum also empty: no basis maintained → None,
+    // so the caller reports 0 rather than dividing by zero.
+    #[test]
+    fn basis_none_when_neither_sum_present() {
+        assert_eq!(resolve_incentive_basis(true, 0, 0), None);
+        assert_eq!(resolve_incentive_basis(false, 0, 0), None);
+    }
 }

--- a/crates/server/src/handlers/runtime_queries/staking.rs
+++ b/crates/server/src/handlers/runtime_queries/staking.rs
@@ -764,6 +764,134 @@ pub async fn get_era_validator_reward(
     None
 }
 
+/// Era-level inputs for the validator self-stake incentive (`pallet_staking_async` / DAP),
+/// fetched **once per era** and shared across every validator in that era.
+///
+/// The self-stake incentive is a validator-only reward pot that is *separate* from
+/// `ErasValidatorReward` (which holds only the staker-reward pool). A validator's incentive is
+/// `floor(share × budget)` where `share = numerator / denominator`.
+///
+/// `weighted` selects **both** halves of that fraction and they MUST stay in lockstep: the
+/// `denominator` here is read from the storage item matching `weighted`, and the numerator built by
+/// `incentive_numerator` (in the payouts handler) branches on the same flag. Changing one without
+/// the other silently rescales every validator's share.
+#[derive(Debug, Clone, Copy)]
+pub struct EraIncentiveContext {
+    /// Era-wide incentive pot (`ErasValidatorIncentiveBudget[era]`).
+    pub budget: u128,
+    /// Shared share denominator: `ErasSumWeightedPoints[era]` when `weighted`, else
+    /// `ErasSumValidatorIncentiveWeight[era]`.
+    pub denominator: u128,
+    /// Whether the era uses the weighted-points formula (numerator = `weight × validator_points`).
+    pub weighted: bool,
+}
+
+/// Build the per-era incentive context, or `None` when the incentive is not applicable:
+/// on any runtime without `pallet_staking_async` (detected via **metadata only — no RPC**) or on
+/// eras with a zero budget. Callers treat `None` as "no incentive" (fields serialise `0`).
+///
+/// Fetching the era-level inputs here (once) rather than per validator avoids O(validators)
+/// redundant storage round-trips.
+pub async fn get_era_incentive_context(
+    client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
+    era: u32,
+) -> Option<EraIncentiveContext> {
+    // Metadata-only gate: on chains without the async-staking pallet the storage item is absent,
+    // so skip all incentive reads without issuing a single RPC.
+    if client_at_block
+        .storage()
+        .entry(("Staking", "ErasValidatorIncentiveBudget"))
+        .is_err()
+    {
+        return None;
+    }
+
+    // Budget and the weighted-points flag are independent reads — fetch them concurrently.
+    let (budget, weighted) = tokio::join!(
+        fetch_era_u128(client_at_block, "ErasValidatorIncentiveBudget", era),
+        uses_weighted_points(client_at_block, era),
+    );
+    if budget == 0 {
+        return None;
+    }
+
+    // Denominator source MUST match the numerator basis chosen by `incentive_numerator`.
+    let denominator = if weighted {
+        fetch_era_u128(client_at_block, "ErasSumWeightedPoints", era).await
+    } else {
+        fetch_era_u128(client_at_block, "ErasSumValidatorIncentiveWeight", era).await
+    };
+
+    Some(EraIncentiveContext {
+        budget,
+        denominator,
+        weighted,
+    })
+}
+
+/// Get a validator's per-era incentive weight from `Staking.ErasValidatorIncentiveWeight`
+/// (double map `(era, validator) -> IncentiveWeight`; `IncentiveWeight = BalanceOf = u128`).
+/// Returns `0` when absent.
+pub async fn get_validator_incentive_weight(
+    client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
+    era: u32,
+    validator_bytes: &[u8; 32],
+) -> u128 {
+    let storage_addr = subxt::dynamic::storage::<_, ()>("Staking", "ErasValidatorIncentiveWeight");
+
+    if let Ok(value) = client_at_block
+        .storage()
+        .fetch(storage_addr, (era, *validator_bytes))
+        .await
+        && let Ok(weight) = u128::decode(&mut &value.into_bytes()[..])
+    {
+        return weight;
+    }
+
+    0
+}
+
+/// Fetch an era-keyed `u128` staking storage value (`StorageMap<EraIndex, _>`), returning `0` when
+/// the key or item is absent. Private helper shared by the incentive budget/denominator reads;
+/// the storage-item name never leaves this module, so callers cannot pass a mistyped name.
+async fn fetch_era_u128(
+    client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
+    storage_name: &str,
+    era: u32,
+) -> u128 {
+    let storage_addr = subxt::dynamic::storage::<_, ()>("Staking", storage_name);
+
+    if let Ok(value) = client_at_block.storage().fetch(storage_addr, (era,)).await
+        && let Ok(v) = u128::decode(&mut &value.into_bytes()[..])
+    {
+        return v;
+    }
+
+    0
+}
+
+/// Whether an era uses the weighted-points incentive formula.
+///
+/// Mirrors `pallet_staking_async`'s `uses_weighted_points`: reads
+/// `Staking.WeightedPointsFormulaStartEra` (`StorageValue<EraIndex, OptionQuery>`). `None` (unset,
+/// or item absent) means "weighted"; otherwise the era is weighted iff `era >= start` — exactly
+/// the pallet's `map_or(true, |start| era >= start)`.
+async fn uses_weighted_points(
+    client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
+    era: u32,
+) -> bool {
+    let storage_addr = subxt::dynamic::storage::<_, ()>("Staking", "WeightedPointsFormulaStartEra");
+
+    // Unset / absent / undecodable all collapse to `None` → the pallet's "default weighted" case.
+    client_at_block
+        .storage()
+        .fetch(storage_addr, ())
+        .await
+        .ok()
+        .and_then(|value| u32::decode(&mut &value.into_bytes()[..]).ok())
+        .is_none_or(|start| era >= start)
+}
+
 /// Get validator preferences (commission) for an era.
 ///
 /// Returns `Some(commission)` if found, `None` otherwise.


### PR DESCRIPTION
Closes #377

### Description

Since the DAP staking change (ref 1909), a validator's era reward is split into staker rewards (`Staking.ErasValidatorReward`) and a separate validator self-stake incentive (`Staking.ErasValidatorIncentiveBudget`). The `staking-payouts` endpoint only read the staker pool, so it under-reported validator rewards by about 1/3 globally, and by over 98% for a validator's own account.

This adds two new read-only response fields and leaves the existing `totalEraPayout` and `nominatorStakingPayout` unchanged (so nothing breaks for current consumers):

- `totalEraSelfStakeIncentivePayout` (per era): the era-wide incentive pot.
- `validatorSelfStakeIncentive` (per validator): that validator's incentive for the era.

Both are `"0"` on chains without `pallet_staking_async`. The share math mirrors the pallet exactly (`Perbill` rounding; weighted-points vs legacy branch). Closes #377.

### Changes by file

- `runtime_queries/staking.rs`: adds the storage reads. `get_era_incentive_context` fetches the era-level inputs (pot, denominator, formula flag) once per era, behind a metadata check that skips all reads on chains without the pallet (no extra RPC). Adds a per-validator weight read.
- `common/accounts/staking_payouts.rs`: fetches the era context once and passes it into `build_payouts`. Adds two small pure functions that compute a validator's incentive as `floor(share * budget)`, plus unit tests.
- `accounts/types.rs`: adds the two new fields to the response types and a `From` impl that builds the response from the raw data (shared by both handlers).
- `accounts/get_staking_payouts.rs` and `rc/accounts/get_staking_payouts.rs`: use the shared `From` impl instead of duplicated mapping code.
- `common/accounts/mod.rs`: drops an unused re-export.

### How to test and verify


Offline checks (no node needed):

```
cargo +nightly-2026-06-16 fmt --all -- --check
cargo +nightly-2026-06-16 clippy --package polkadot-rest-api --all-features -- -D warnings
cargo test --workspace --exclude integration_tests --lib
cargo test --package polkadot-rest-api --lib staking_payouts::tests
```

Live check against an Asset Hub node (verifies the real values):

```
SAS_SUBSTRATE_URL=wss://polkadot-asset-hub-rpc.polkadot.io cargo run --release --bin polkadot-rest-api
curl -s "http://127.0.0.1:8080/v1/accounts/15a9ScnYeVfQGL9HQtTn3nkUY1DTB8LzEX391yZvFRzJZ9V7/staking-payouts?era=2222&unclaimedOnly=false" | jq '.erasPayouts[0]'
```

- Expect `totalEraSelfStakeIncentivePayout` about `346078200000000` (34,607.82 DOT).
- Expect the validator's `validatorSelfStakeIncentive` about `415663086459` (41.57 DOT).

Legacy chain check (no async-staking pallet):

```
SAS_SUBSTRATE_URL=wss://rpc.polkadot.io cargo run --release --bin polkadot-rest-api
curl -s "http://127.0.0.1:8080/v1/accounts/<nominator>/staking-payouts" | jq '.erasPayouts[0].totalEraSelfStakeIncentivePayout'
```

- Expect `"0"` and no added latency (the metadata check skips all incentive reads).

Integration tests (need a live Asset Hub node):

```
SAS_SUBSTRATE_URL=wss://polkadot-asset-hub-rpc.polkadot.io cargo test --package integration_tests staking_payouts
```



