### PR TITLE
fix: surface transient storage failures instead of returning free:0

### DIFF
--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -1470,19 +1470,10 @@ mod tests {
 mod status_response_tests {
     use super::*;
     use crate::handlers::common::accounts::query_balance_info;
-    use crate::test_fixtures::{TEST_BLOCK_NUMBER, mock_rpc_client_builder};
+    use crate::test_fixtures::{TEST_BLOCK_NUMBER, mock_rpc_client_builder, online_client};
     use crate::utils::ResolvedBlock;
     use sp_core::crypto::AccountId32;
-    use subxt::{OnlineClient, SubstrateConfig};
     use subxt_rpcs::client::mock_rpc_client::Json as MockJson;
-    use subxt_rpcs::client::{MockRpcClient, RpcClient};
-
-    async fn online_client(mock: MockRpcClient) -> OnlineClient<SubstrateConfig> {
-        let rpc_client = RpcClient::new(mock);
-        OnlineClient::<SubstrateConfig>::from_rpc_client(rpc_client)
-            .await
-            .expect("failed to build OnlineClient over mock")
-    }
 
     /// Run `query_balance_info` against a node that fails every `System::Account` read with the
     /// error `make_err` produces, and return the HTTP status that error maps to.

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -4,7 +4,10 @@
 //! Types for account-related handlers.
 
 use super::utils::AddressValidationError;
-use crate::handlers::common::accounts::{RawEraPayouts, StakingPayoutsQueryError};
+use crate::handlers::common::accounts::{
+    BalanceQueryError, ProxyQueryError, RawEraPayouts, StakingPayoutsQueryError, StakingQueryError,
+    VestingQueryError,
+};
 use crate::state::RelayChainError;
 use crate::utils::{self, RcBlockError};
 use axum::{Json, http::StatusCode, response::IntoResponse};
@@ -393,8 +396,49 @@ impl From<StakingPayoutsQueryError> for AccountsError {
     }
 }
 
+/// Shared 503 body (no internal detail leaked).
+const SERVICE_UNAVAILABLE_MSG: &str = "Service temporarily unavailable";
+
+/// Extract the inner [`StorageError`] from any account sub-query's `StorageQueryFailed` variant.
+fn storage_query_error(err: &AccountsError) -> Option<&StorageError> {
+    match err {
+        AccountsError::StorageQueryFailed(e) => Some(e),
+        AccountsError::BalanceQueryFailed(inner) => match inner.as_ref() {
+            BalanceQueryError::StorageQueryFailed(e) => Some(e),
+            _ => None,
+        },
+        AccountsError::ProxyQueryFailed(inner) => match inner.as_ref() {
+            ProxyQueryError::StorageQueryFailed(e) => Some(e),
+            _ => None,
+        },
+        AccountsError::VestingQueryFailed(inner) => match inner.as_ref() {
+            VestingQueryError::StorageQueryFailed(e) => Some(e),
+            _ => None,
+        },
+        AccountsError::StakingQueryFailed(inner) => match inner.as_ref() {
+            StakingQueryError::StorageQueryFailed(e) => Some(e),
+            _ => None,
+        },
+        AccountsError::StakingPayoutsQueryFailed(inner) => match inner.as_ref() {
+            StakingPayoutsQueryError::StorageQueryFailed(e) => Some(e),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
 impl IntoResponse for AccountsError {
     fn into_response(self) -> axum::response::Response {
+        // Transient storage failures (any sub-query) are retryable: 503, not 500.
+        if let Some(storage_err) = storage_query_error(&self)
+            && utils::is_transient_storage_error(storage_err)
+        {
+            return error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                SERVICE_UNAVAILABLE_MSG.to_string(),
+            );
+        }
+
         let (status, message) = match &self {
             AccountsError::InvalidBlockParam(_)
             | AccountsError::InvalidAddress(_)
@@ -426,7 +470,7 @@ impl IntoResponse for AccountsError {
                 if utils::is_online_client_at_block_disconnected(err) {
                     (
                         StatusCode::SERVICE_UNAVAILABLE,
-                        "Service temporarily unavailable".to_string(),
+                        SERVICE_UNAVAILABLE_MSG.to_string(),
                     )
                 } else {
                     (StatusCode::INTERNAL_SERVER_ERROR, self.to_string())
@@ -443,6 +487,7 @@ impl IntoResponse for AccountsError {
             AccountsError::PartialAssetBalances(_) | AccountsError::AssetIdsQueryFailed => {
                 (StatusCode::SERVICE_UNAVAILABLE, self.to_string())
             }
+            // Transient storage failures are handled by the early return above.
             _ => (StatusCode::INTERNAL_SERVER_ERROR, self.to_string()),
         };
         error_response(status, message)
@@ -1417,5 +1462,56 @@ mod tests {
         let _: AccountConvertQueryParams = serde_json::from_str(json).unwrap();
         let _: AccountValidateQueryParams = serde_json::from_str(json).unwrap();
         let _: ForeignAssetBalancesQueryParams = serde_json::from_str(json).unwrap();
+    }
+}
+
+/// Status-mapping tests over the mock-RPC harness.
+#[cfg(test)]
+mod status_response_tests {
+    use super::*;
+    use crate::handlers::common::accounts::query_balance_info;
+    use crate::test_fixtures::{TEST_BLOCK_NUMBER, mock_rpc_client_builder};
+    use crate::utils::ResolvedBlock;
+    use sp_core::crypto::AccountId32;
+    use subxt::{OnlineClient, SubstrateConfig};
+    use subxt_rpcs::client::mock_rpc_client::Json as MockJson;
+    use subxt_rpcs::client::{MockRpcClient, RpcClient};
+
+    async fn online_client(mock: MockRpcClient) -> OnlineClient<SubstrateConfig> {
+        let rpc_client = RpcClient::new(mock);
+        OnlineClient::<SubstrateConfig>::from_rpc_client(rpc_client)
+            .await
+            .expect("failed to build OnlineClient over mock")
+    }
+
+    /// A transient `System::Account` fetch failure maps to HTTP 503.
+    #[tokio::test]
+    async fn transient_storage_failure_maps_to_503() {
+        let mock = mock_rpc_client_builder()
+            .method_handler("state_getStorage", async |_params| {
+                Err::<MockJson<String>, subxt_rpcs::Error>(subxt_rpcs::Error::Client(Box::new(
+                    // "Request timeout" is what `is_timeout_error` keys on → classified transient.
+                    std::io::Error::new(std::io::ErrorKind::TimedOut, "Request timeout"),
+                )))
+            })
+            .build();
+
+        let client = online_client(mock).await;
+        let at = client
+            .at_block(TEST_BLOCK_NUMBER)
+            .await
+            .expect("at_block failed");
+        let block = ResolvedBlock {
+            hash: format!("0x{}", "0".repeat(64)),
+            number: TEST_BLOCK_NUMBER,
+        };
+        let account = AccountId32::new([1u8; 32]);
+
+        let err = query_balance_info(&at, "polkadot", &account, &block, None)
+            .await
+            .expect_err("a timed-out storage fetch must be an error, not free:0");
+
+        let response = AccountsError::from(err).into_response();
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
     }
 }

--- a/crates/server/src/handlers/accounts/types.rs
+++ b/crates/server/src/handlers/accounts/types.rs
@@ -1484,15 +1484,19 @@ mod status_response_tests {
             .expect("failed to build OnlineClient over mock")
     }
 
-    /// A transient `System::Account` fetch failure maps to HTTP 503.
-    #[tokio::test]
-    async fn transient_storage_failure_maps_to_503() {
+    /// Run `query_balance_info` against a node that fails every `System::Account` read with the
+    /// error `make_err` produces, and return the HTTP status that error maps to.
+    ///
+    /// Takes a factory rather than a value because `subxt_rpcs::Error` is not `Clone` and the mock
+    /// handler may be called more than once.
+    async fn balance_info_status_for<F>(make_err: F) -> StatusCode
+    where
+        F: Fn() -> subxt_rpcs::Error + Clone + Send + Sync + 'static,
+    {
         let mock = mock_rpc_client_builder()
-            .method_handler("state_getStorage", async |_params| {
-                Err::<MockJson<String>, subxt_rpcs::Error>(subxt_rpcs::Error::Client(Box::new(
-                    // "Request timeout" is what `is_timeout_error` keys on → classified transient.
-                    std::io::Error::new(std::io::ErrorKind::TimedOut, "Request timeout"),
-                )))
+            .method_handler("state_getStorage", move |_params| {
+                let make_err = make_err.clone();
+                async move { Err::<MockJson<String>, subxt_rpcs::Error>(make_err()) }
             })
             .build();
 
@@ -1507,11 +1511,52 @@ mod status_response_tests {
         };
         let account = AccountId32::new([1u8; 32]);
 
-        let err = query_balance_info(&at, "polkadot", &account, &block, None)
+        let query_err = query_balance_info(&at, "polkadot", &account, &block, None)
             .await
-            .expect_err("a timed-out storage fetch must be an error, not free:0");
+            .expect_err("a failed storage fetch must be an error, not free:0");
 
-        let response = AccountsError::from(err).into_response();
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        AccountsError::from(query_err).into_response().status()
+    }
+
+    /// A timed-out `System::Account` fetch maps to HTTP 503.
+    #[tokio::test]
+    async fn transient_storage_failure_maps_to_503() {
+        let status = balance_info_status_for(|| {
+            subxt_rpcs::Error::Client(Box::new(std::io::Error::new(
+                std::io::ErrorKind::TimedOut,
+                "Request timeout",
+            )))
+        })
+        .await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// A transport failure whose `Display` is not "Request timeout" — a connection reset, a TLS
+    /// failure, a closed socket — is still an upstream blip and must map to 503, not 500.
+    #[tokio::test]
+    async fn non_timeout_transport_failure_maps_to_503() {
+        let status = balance_info_status_for(|| {
+            subxt_rpcs::Error::Client(Box::new(std::io::Error::new(
+                std::io::ErrorKind::ConnectionReset,
+                "connection reset by peer",
+            )))
+        })
+        .await;
+        assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+    }
+
+    /// The node answering with a JSON-RPC error (e.g. `at=` inside pruned state) is definitive,
+    /// not retryable, so it must not be advertised as 503.
+    #[tokio::test]
+    async fn node_json_rpc_error_does_not_map_to_503() {
+        let status = balance_info_status_for(|| {
+            subxt_rpcs::Error::User(subxt_rpcs::UserError {
+                code: -32000,
+                message: "State already discarded for hash".to_string(),
+                data: None,
+            })
+        })
+        .await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
     }
 }

--- a/crates/server/src/handlers/common/accounts/balance_info.rs
+++ b/crates/server/src/handlers/common/accounts/balance_info.rs
@@ -74,6 +74,19 @@ impl From<subxt::error::StorageError> for BalanceQueryError {
     }
 }
 
+impl From<balances_queries::AccountDataError> for BalanceQueryError {
+    fn from(err: balances_queries::AccountDataError) -> Self {
+        use balances_queries::AccountDataError;
+        match err {
+            // Fetch failure stays retryable (503); decode failure does not (500).
+            AccountDataError::Fetch(e) => BalanceQueryError::StorageQueryFailed(Box::new(e)),
+            AccountDataError::Decode(_) => BalanceQueryError::DecodeFailed(
+                "unrecognized System::Account storage layout".into(),
+            ),
+        }
+    }
+}
+
 // ================================================================================================
 // Main Query Function
 // ================================================================================================
@@ -121,6 +134,10 @@ pub async fn query_balance_info(
         balances_queries::get_account_data_or_default(client_at_block, account),
         balances_queries::get_balance_locks(client_at_block, account)
     );
+
+    // Propagate fetch/decode errors instead of serving false-zero or empty data.
+    let account_data = account_data?;
+    let locks = locks?;
 
     // Calculate transferable balance using the dynamically fetched ED
     let transferable = calculate_transferable(existential_deposit, &account_data);

--- a/crates/server/src/handlers/common/accounts/balance_info.rs
+++ b/crates/server/src/handlers/common/accounts/balance_info.rs
@@ -58,6 +58,14 @@ pub enum BalanceQueryError {
     #[error("Failed to decode storage value: {0}")]
     DecodeFailed(#[from] parity_scale_codec::Error),
 
+    /// `System::Account` bytes matched no layout we understand. Separate from [`Self::DecodeFailed`]
+    /// because that wraps `parity_scale_codec::Error`, which only converts from `&'static str` —
+    /// a `format!`-built string carrying the byte count cannot go through it.
+    #[error(
+        "Failed to decode storage value: unrecognized System::Account storage layout ({0} bytes)"
+    )]
+    AccountLayoutUnknown(usize),
+
     #[error("Failed to fetch ExistentialDeposit constant from runtime")]
     ExistentialDepositFetchFailed,
 }
@@ -80,9 +88,7 @@ impl From<balances_queries::AccountDataError> for BalanceQueryError {
         match err {
             // Fetch failure stays retryable (503); decode failure does not (500).
             AccountDataError::Fetch(e) => BalanceQueryError::StorageQueryFailed(Box::new(e)),
-            AccountDataError::Decode(_) => BalanceQueryError::DecodeFailed(
-                "unrecognized System::Account storage layout".into(),
-            ),
+            AccountDataError::Decode(len) => BalanceQueryError::AccountLayoutUnknown(len),
         }
     }
 }
@@ -331,4 +337,32 @@ pub fn format_locks(
             reasons: lock.reasons.clone(),
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The byte count in `AccountDataError::Decode` must survive the conversion and reach the
+    /// rendered message — carrying it is the whole point of a dedicated variant.
+    #[test]
+    fn account_layout_error_carries_the_byte_count() {
+        let err = BalanceQueryError::from(balances_queries::AccountDataError::Decode(10));
+
+        assert!(matches!(err, BalanceQueryError::AccountLayoutUnknown(10)));
+        assert_eq!(
+            err.to_string(),
+            "Failed to decode storage value: unrecognized System::Account storage layout (10 bytes)"
+        );
+    }
+
+    /// A fetch failure must keep taking the retryable path, not the new decode variant.
+    #[test]
+    fn fetch_error_stays_a_storage_query_failure() {
+        let err = BalanceQueryError::from(balances_queries::AccountDataError::Fetch(
+            subxt::error::StorageError::NoValueFound,
+        ));
+
+        assert!(matches!(err, BalanceQueryError::StorageQueryFailed(_)));
+    }
 }

--- a/crates/server/src/handlers/common/accounts/proxy_info.rs
+++ b/crates/server/src/handlers/common/accounts/proxy_info.rs
@@ -120,7 +120,7 @@ pub async fn query_proxy_info(
 
     // Use centralized query function
     let (delegated_accounts, deposit_held) = if let Some((proxies, deposit)) =
-        balances_queries::get_proxy_definitions(client_at_block, account, ss58_prefix).await
+        balances_queries::get_proxy_definitions(client_at_block, account, ss58_prefix).await?
     {
         let definitions = proxies
             .into_iter()

--- a/crates/server/src/handlers/common/accounts/vesting_info.rs
+++ b/crates/server/src/handlers/common/accounts/vesting_info.rs
@@ -99,7 +99,8 @@ pub async fn query_vesting_info(
     }
 
     // Use centralized query function
-    let vesting_schedules = balances_queries::get_vesting_schedules(client_at_block, account).await;
+    let vesting_schedules =
+        balances_queries::get_vesting_schedules(client_at_block, account).await?;
 
     // Convert to decoded schedules
     let schedules: Vec<DecodedVestingSchedule> = vesting_schedules

--- a/crates/server/src/handlers/runtime_queries/balances.rs
+++ b/crates/server/src/handlers/runtime_queries/balances.rs
@@ -665,7 +665,11 @@ mod rpc_fetch_tests {
 
     #[tokio::test]
     async fn absent_account_yields_zero() {
-        // `null` response => no value at the key => legitimate zero balance.
+        // `null` response => subxt substitutes the metadata default for `System::Account`
+        // (`try_fetch` ends in `.or_else(|| self.default_value())`), so this decodes a zeroed
+        // AccountInfo => legitimate zero balance. The `Ok(None)` fallback in
+        // `get_account_data_or_default` is a safety net for metadata without a default and is
+        // not reachable through this path.
         let mock = mock_rpc_client_builder()
             .method_handler("state_getStorage", async |_params| {
                 MockJson(Option::<String>::None)

--- a/crates/server/src/handlers/runtime_queries/balances.rs
+++ b/crates/server/src/handlers/runtime_queries/balances.rs
@@ -274,6 +274,21 @@ pub async fn get_vesting_schedules(
 // Decoding Functions
 // ================================================================================================
 
+/// Log storage bytes we fetched but could not decode: byte length plus the first 32 bytes as hex.
+///
+/// Every caller below returns `None` on an unrecognized layout, and for locks, proxies and vesting
+/// that degrades to an empty field with HTTP 200 rather than failing the request. This log line is
+/// therefore the only signal that a runtime upgrade changed a layout we thought we understood.
+fn warn_undecodable(what: &str, raw_bytes: &[u8]) {
+    let len = raw_bytes.len();
+    tracing::warn!(
+        "Failed to decode {} ({} bytes): 0x{}",
+        what,
+        len,
+        hex::encode(&raw_bytes[..len.min(32)])
+    );
+}
+
 fn decode_account_info(raw_bytes: &[u8]) -> Option<DecodedAccountData> {
     let len = raw_bytes.len();
 
@@ -340,16 +355,15 @@ fn decode_account_info(raw_bytes: &[u8]) -> Option<DecodedAccountData> {
     // SCALE Decode will happily consume a prefix of a larger buffer, which would silently
     // return wrong data for future runtime layouts with a different size. If we encounter
     // an unknown size, log it and return None so the caller can handle it gracefully.
-    tracing::warn!(
-        "Failed to decode AccountInfo ({} bytes): 0x{}",
-        len,
-        hex::encode(&raw_bytes[..len.min(32)])
-    );
+    warn_undecodable("AccountInfo", raw_bytes);
     None
 }
 
 fn decode_balance_locks(raw_bytes: &[u8]) -> Option<Vec<DecodedBalanceLock>> {
-    let locks = Vec::<BalanceLock>::decode(&mut &raw_bytes[..]).ok()?;
+    let Ok(locks) = Vec::<BalanceLock>::decode(&mut &raw_bytes[..]) else {
+        warn_undecodable("Balances::Locks", raw_bytes);
+        return None;
+    };
 
     Some(
         locks
@@ -374,8 +388,10 @@ fn decode_proxy_definitions(
 
     // Proxy storage is (Vec<ProxyDefinition>, deposit)
     // Try decoding the tuple
-    let (proxies, deposit): (Vec<ProxyDefinition>, u128) =
-        Decode::decode(&mut &raw_bytes[..]).ok()?;
+    let Ok((proxies, deposit)) = <(Vec<ProxyDefinition>, u128)>::decode(&mut &raw_bytes[..]) else {
+        warn_undecodable("Proxy::Proxies", raw_bytes);
+        return None;
+    };
 
     let decoded_proxies = proxies
         .into_iter()
@@ -423,6 +439,10 @@ fn decode_vesting_schedules(raw_bytes: &[u8]) -> Option<Vec<DecodedVestingInfo>>
         );
     }
 
+    // Both layouts exhausted. Reaching here means the bytes are neither a `Vec<VestingInfo>` nor
+    // an `Option<Vec<VestingInfo>>` — a legitimately empty schedule list decodes as an empty `Vec`
+    // in the first attempt, so this is a real layout mismatch, not "no vesting".
+    warn_undecodable("Vesting::Vesting", raw_bytes);
     None
 }
 

--- a/crates/server/src/handlers/runtime_queries/balances.rs
+++ b/crates/server/src/handlers/runtime_queries/balances.rs
@@ -610,17 +610,8 @@ mod tests {
 #[cfg(test)]
 mod rpc_fetch_tests {
     use super::*;
-    use crate::test_fixtures::{TEST_BLOCK_NUMBER, mock_rpc_client_builder};
-    use subxt::{OnlineClient, SubstrateConfig};
+    use crate::test_fixtures::{TEST_BLOCK_NUMBER, mock_rpc_client_builder, online_client};
     use subxt_rpcs::client::mock_rpc_client::Json as MockJson;
-    use subxt_rpcs::client::{MockRpcClient, RpcClient};
-
-    async fn online_client(mock: MockRpcClient) -> OnlineClient<SubstrateConfig> {
-        let rpc_client = RpcClient::new(mock);
-        OnlineClient::<SubstrateConfig>::from_rpc_client(rpc_client)
-            .await
-            .expect("failed to build OnlineClient over mock")
-    }
 
     fn test_account() -> AccountId32 {
         AccountId32::new([1u8; 32])

--- a/crates/server/src/handlers/runtime_queries/balances.rs
+++ b/crates/server/src/handlers/runtime_queries/balances.rs
@@ -161,31 +161,65 @@ pub struct DecodedVestingInfo {
 // Storage Query Functions
 // ================================================================================================
 
-/// Get account data from System::Account storage.
+/// Error reading an account's `System::Account` entry.
+#[derive(Debug, thiserror::Error)]
+pub enum AccountDataError {
+    /// The storage fetch failed (transient / retryable).
+    #[error(transparent)]
+    Fetch(#[from] subxt::error::StorageError),
+
+    /// Bytes were fetched but matched no known `AccountInfo` layout.
+    #[error("failed to decode AccountInfo storage value ({0} bytes)")]
+    Decode(usize),
+}
+
+/// Fetch the raw SCALE bytes of an account-keyed map storage entry.
+///
+/// `Ok(Some(bytes))` if present, `Ok(None)` if genuinely absent, `Err` if the fetch failed.
+async fn try_fetch_storage(
+    client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
+    pallet: &str,
+    entry: &str,
+    account: &AccountId32,
+) -> Result<Option<Vec<u8>>, subxt::error::StorageError> {
+    let storage_addr = subxt::dynamic::storage::<_, ()>(pallet, entry);
+    let account_bytes: [u8; 32] = *account.as_ref();
+
+    Ok(client_at_block
+        .storage()
+        .try_fetch(storage_addr, (account_bytes,))
+        .await?
+        .map(|value| value.into_bytes()))
+}
+
+/// Read and decode an account's `System::Account` entry.
+///
+/// `Ok(Some)` if present and decoded, `Ok(None)` if genuinely absent, `Err(Fetch)` on a fetch
+/// failure, `Err(Decode)` if the bytes matched no known layout.
 pub async fn get_account_data(
     client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
     account: &AccountId32,
-) -> Option<DecodedAccountData> {
-    let storage_addr = subxt::dynamic::storage::<_, ()>("System", "Account");
-    let account_bytes: [u8; 32] = *account.as_ref();
+) -> Result<Option<DecodedAccountData>, AccountDataError> {
+    let Some(raw_bytes) = try_fetch_storage(client_at_block, "System", "Account", account).await?
+    else {
+        return Ok(None);
+    };
 
-    let value = client_at_block
-        .storage()
-        .fetch(storage_addr, (account_bytes,))
-        .await
-        .ok()?;
-
-    let raw_bytes = value.into_bytes();
-    decode_account_info(&raw_bytes)
+    // Bytes present but undecodable is an error, not an absent account.
+    match decode_account_info(&raw_bytes) {
+        Some(data) => Ok(Some(data)),
+        None => Err(AccountDataError::Decode(raw_bytes.len())),
+    }
 }
 
-/// Get account data, returning default values if account doesn't exist.
+/// Like [`get_account_data`], but returns zeroed balances for a genuinely-absent account.
+/// Fetch and decode errors still propagate — never a fabricated `free: 0`.
 pub async fn get_account_data_or_default(
     client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
     account: &AccountId32,
-) -> DecodedAccountData {
-    get_account_data(client_at_block, account)
-        .await
+) -> Result<DecodedAccountData, AccountDataError> {
+    Ok(get_account_data(client_at_block, account)
+        .await?
         .unwrap_or(DecodedAccountData {
             nonce: 0,
             free: 0,
@@ -193,74 +227,47 @@ pub async fn get_account_data_or_default(
             misc_frozen: None,
             fee_frozen: None,
             frozen: Some(0),
-        })
+        }))
 }
 
-/// Get balance locks from Balances::Locks storage.
+/// Get balance locks from `Balances::Locks` (empty when absent; `Err` on fetch failure).
 pub async fn get_balance_locks(
     client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
     account: &AccountId32,
-) -> Vec<DecodedBalanceLock> {
-    let storage_addr = subxt::dynamic::storage::<_, ()>("Balances", "Locks");
-    let account_bytes: [u8; 32] = *account.as_ref();
-
-    let value = match client_at_block
-        .storage()
-        .fetch(storage_addr, (account_bytes,))
-        .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::debug!("Failed to fetch balance locks: {e:?}");
-            return Vec::new();
-        }
+) -> Result<Vec<DecodedBalanceLock>, subxt::error::StorageError> {
+    let Some(raw_bytes) = try_fetch_storage(client_at_block, "Balances", "Locks", account).await?
+    else {
+        return Ok(Vec::new());
     };
 
-    let raw_bytes = value.into_bytes();
-    decode_balance_locks(&raw_bytes).unwrap_or_default()
+    Ok(decode_balance_locks(&raw_bytes).unwrap_or_default())
 }
 
-/// Get proxy definitions from Proxy::Proxies storage.
+/// Get proxy definitions from `Proxy::Proxies` (`None` when absent; `Err` on fetch failure).
 pub async fn get_proxy_definitions(
     client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
     account: &AccountId32,
     ss58_prefix: u16,
-) -> Option<(Vec<DecodedProxyDefinition>, u128)> {
-    let storage_addr = subxt::dynamic::storage::<_, ()>("Proxy", "Proxies");
-    let account_bytes: [u8; 32] = *account.as_ref();
+) -> Result<Option<(Vec<DecodedProxyDefinition>, u128)>, subxt::error::StorageError> {
+    let Some(raw_bytes) = try_fetch_storage(client_at_block, "Proxy", "Proxies", account).await?
+    else {
+        return Ok(None);
+    };
 
-    let value = client_at_block
-        .storage()
-        .fetch(storage_addr, (account_bytes,))
-        .await
-        .ok()?;
-
-    let raw_bytes = value.into_bytes();
-    decode_proxy_definitions(&raw_bytes, ss58_prefix)
+    Ok(decode_proxy_definitions(&raw_bytes, ss58_prefix))
 }
 
-/// Get vesting schedules from Vesting::Vesting storage.
+/// Get vesting schedules from `Vesting::Vesting` (empty when absent; `Err` on fetch failure).
 pub async fn get_vesting_schedules(
     client_at_block: &OnlineClientAtBlock<SubstrateConfig>,
     account: &AccountId32,
-) -> Vec<DecodedVestingInfo> {
-    let storage_addr = subxt::dynamic::storage::<_, ()>("Vesting", "Vesting");
-    let account_bytes: [u8; 32] = *account.as_ref();
-
-    let value = match client_at_block
-        .storage()
-        .fetch(storage_addr, (account_bytes,))
-        .await
-    {
-        Ok(v) => v,
-        Err(e) => {
-            tracing::debug!("Failed to fetch vesting schedules: {e:?}");
-            return Vec::new();
-        }
+) -> Result<Vec<DecodedVestingInfo>, subxt::error::StorageError> {
+    let Some(raw_bytes) = try_fetch_storage(client_at_block, "Vesting", "Vesting", account).await?
+    else {
+        return Ok(Vec::new());
     };
 
-    let raw_bytes = value.into_bytes();
-    decode_vesting_schedules(&raw_bytes).unwrap_or_default()
+    Ok(decode_vesting_schedules(&raw_bytes).unwrap_or_default())
 }
 
 // ================================================================================================
@@ -573,5 +580,138 @@ mod tests {
         assert_eq!(build_modern_bytes(0, 0, 0, 0).len(), 80);
         assert_eq!(build_pre_sufficients_bytes(0, 0, 0, 0, 0).len(), 76);
         assert_eq!(build_refcount_bytes(0, 0, 0, 0, 0, 0).len(), 69);
+    }
+}
+
+/// End-to-end tests for `get_account_data_or_default` driven over a mock RPC client.
+///
+/// These guard the false-zero regression: a failed `System::Account` fetch must surface
+/// as an error, while a present or genuinely-absent account must decode correctly.
+#[cfg(test)]
+mod rpc_fetch_tests {
+    use super::*;
+    use crate::test_fixtures::{TEST_BLOCK_NUMBER, mock_rpc_client_builder};
+    use subxt::{OnlineClient, SubstrateConfig};
+    use subxt_rpcs::client::mock_rpc_client::Json as MockJson;
+    use subxt_rpcs::client::{MockRpcClient, RpcClient};
+
+    async fn online_client(mock: MockRpcClient) -> OnlineClient<SubstrateConfig> {
+        let rpc_client = RpcClient::new(mock);
+        OnlineClient::<SubstrateConfig>::from_rpc_client(rpc_client)
+            .await
+            .expect("failed to build OnlineClient over mock")
+    }
+
+    fn test_account() -> AccountId32 {
+        AccountId32::new([1u8; 32])
+    }
+
+    /// Build an 80-byte modern `AccountInfo` payload with the given free balance.
+    fn modern_account_bytes(free: u128) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(80);
+        buf.extend_from_slice(&0u32.to_le_bytes()); // nonce
+        buf.extend_from_slice(&1u32.to_le_bytes()); // consumers
+        buf.extend_from_slice(&1u32.to_le_bytes()); // providers
+        buf.extend_from_slice(&0u32.to_le_bytes()); // sufficients
+        buf.extend_from_slice(&free.to_le_bytes()); // free
+        buf.extend_from_slice(&0u128.to_le_bytes()); // reserved
+        buf.extend_from_slice(&0u128.to_le_bytes()); // frozen
+        buf.extend_from_slice(&0u128.to_le_bytes()); // flags
+        buf
+    }
+
+    #[tokio::test]
+    async fn present_account_returns_real_balance() {
+        let free = 100_000_000u128;
+        let hex = format!("0x{}", hex::encode(modern_account_bytes(free)));
+        let mock = mock_rpc_client_builder()
+            .method_handler("state_getStorage", move |_params| {
+                let hex = hex.clone();
+                async move { MockJson(hex) }
+            })
+            .build();
+
+        let client = online_client(mock).await;
+        let at = client
+            .at_block(TEST_BLOCK_NUMBER)
+            .await
+            .expect("at_block failed");
+
+        let data = get_account_data_or_default(&at, &test_account())
+            .await
+            .expect("a successful fetch must not error");
+        assert_eq!(data.free, free);
+    }
+
+    #[tokio::test]
+    async fn absent_account_yields_zero() {
+        // `null` response => no value at the key => legitimate zero balance.
+        let mock = mock_rpc_client_builder()
+            .method_handler("state_getStorage", async |_params| {
+                MockJson(Option::<String>::None)
+            })
+            .build();
+
+        let client = online_client(mock).await;
+        let at = client
+            .at_block(TEST_BLOCK_NUMBER)
+            .await
+            .expect("at_block failed");
+
+        let data = get_account_data_or_default(&at, &test_account())
+            .await
+            .expect("an absent account is not an error");
+        assert_eq!(data.free, 0);
+    }
+
+    /// Regression guard for the Binance false-zero incident: a transient fetch failure
+    /// must be an error, NOT a fabricated `free: 0`. This fails against the previous
+    /// `.ok()?` implementation (which returned zeroed data) and passes after the fix.
+    #[tokio::test]
+    async fn transient_fetch_error_is_not_false_zero() {
+        let mock = mock_rpc_client_builder()
+            .method_handler("state_getStorage", async |_params| {
+                Err::<MockJson<String>, subxt_rpcs::Error>(subxt_rpcs::Error::Client(Box::new(
+                    std::io::Error::other("simulated transient RPC failure"),
+                )))
+            })
+            .build();
+
+        let client = online_client(mock).await;
+        let at = client
+            .at_block(TEST_BLOCK_NUMBER)
+            .await
+            .expect("at_block failed");
+
+        let result = get_account_data_or_default(&at, &test_account()).await;
+        assert!(
+            result.is_err(),
+            "a failed storage fetch must surface as an error, not free:0"
+        );
+    }
+
+    /// Present-but-undecodable bytes must error, not become `free: 0`.
+    #[tokio::test]
+    async fn undecodable_bytes_are_not_false_zero() {
+        // 10 bytes: matches no known layout.
+        let hex = format!("0x{}", hex::encode([0u8; 10]));
+        let mock = mock_rpc_client_builder()
+            .method_handler("state_getStorage", move |_params| {
+                let hex = hex.clone();
+                async move { MockJson(hex) }
+            })
+            .build();
+
+        let client = online_client(mock).await;
+        let at = client
+            .at_block(TEST_BLOCK_NUMBER)
+            .await
+            .expect("at_block failed");
+
+        let result = get_account_data_or_default(&at, &test_account()).await;
+        assert!(
+            result.is_err(),
+            "present-but-undecodable bytes must surface as an error, not free:0"
+        );
     }
 }

--- a/crates/server/src/test_fixtures/mod.rs
+++ b/crates/server/src/test_fixtures/mod.rs
@@ -10,6 +10,7 @@
 use parity_scale_codec::{Compact, Encode};
 use serde_json::{json, value::RawValue};
 use std::sync::Arc;
+use subxt::{OnlineClient, SubstrateConfig};
 use subxt_rpcs::client::mock_rpc_client::{Json as MockJson, MockRpcClientBuilder};
 use subxt_rpcs::client::{MockRpcClient, RpcClient};
 
@@ -164,6 +165,17 @@ pub fn create_mock_rpc_client() -> MockRpcClient {
 /// Create an RpcClient from the mock.
 pub fn create_rpc_client() -> Arc<RpcClient> {
     Arc::new(RpcClient::new(create_mock_rpc_client()))
+}
+
+/// Build an `OnlineClient` over a mock RPC client, panicking if initialization fails.
+///
+/// Pair with [`mock_rpc_client_builder`], which already answers the handshake calls
+/// (`rpc_methods`, genesis hash, `Core_version`, `Metadata_metadata`) this needs.
+pub async fn online_client(mock: MockRpcClient) -> OnlineClient<SubstrateConfig> {
+    let rpc_client = RpcClient::new(mock);
+    OnlineClient::<SubstrateConfig>::from_rpc_client(rpc_client)
+        .await
+        .expect("failed to build OnlineClient over mock")
 }
 
 #[cfg(test)]

--- a/crates/server/src/utils/mod.rs
+++ b/crates/server/src/utils/mod.rs
@@ -49,20 +49,39 @@ pub fn is_backend_disconnected_error(err: &subxt::error::BackendError) -> bool {
     err.is_disconnected_will_reconnect()
 }
 
-/// Whether a `BackendError` is transient (retryable): disconnect, RPC limit, timeout, or
-/// dropped subscription. Anything else is non-retryable.
+/// Whether a `BackendError` is transient (retryable), i.e. an upstream failure to reach the node
+/// rather than a fault of ours.
+///
+/// Every `BackendError` is a failed conversation with the node, so the default here is "retryable"
+/// (503). Only two classes are excluded, because a retry cannot change the outcome:
+///
+/// - [`subxt_rpcs::Error::User`] — the node *answered*, with a JSON-RPC error (e.g. `-32000 State
+///   already discarded` when `at=` points inside pruned state). A definitive response, not a blip.
+/// - serialization / deserialization / SCALE-decode / insecure-URL — our own request and response
+///   handling, or configuration, not the connection.
+///
+/// Everything else is retryable: `DisconnectedWillReconnect`, `LimitReached`,
+/// `SubscriptionDropped`, request timeouts and any other transport or IO failure, plus
+/// backend-level conditions such as "no available backend" (`BackendError::Other`).
+///
+/// Note this deliberately does not consult [`is_timeout_error`]: timeouts arrive as
+/// `subxt_rpcs::Error::Client`, which is not in the definitive set, so that function's
+/// Display-substring match is not load-bearing for HTTP status selection.
 pub fn is_transient_backend_error(err: &subxt::error::BackendError) -> bool {
     use subxt::error::{BackendError, RpcError};
 
-    if err.is_disconnected_will_reconnect() || err.is_rpc_limit_reached() {
-        return true;
-    }
+    let definitive = matches!(
+        err,
+        BackendError::Rpc(RpcError::ClientError(
+            subxt_rpcs::Error::User(_)
+                | subxt_rpcs::Error::Serialization(_)
+                | subxt_rpcs::Error::Deserialization(_)
+                | subxt_rpcs::Error::Decode(_)
+                | subxt_rpcs::Error::InsecureUrl(_),
+        ))
+    );
 
-    match err {
-        BackendError::Rpc(RpcError::ClientError(rpc_err)) => is_timeout_error(rpc_err),
-        BackendError::Rpc(RpcError::SubscriptionDropped) => true,
-        _ => false,
-    }
+    !definitive
 }
 
 /// Whether a `StorageError` is transient (retryable): a `BackendError`-wrapping variant whose
@@ -166,6 +185,15 @@ mod rpc_error_tests {
         subxt_rpcs::Error::Client(Box::new(std::io::Error::other("Some other error")))
     }
 
+    /// Helper to create a node-returned JSON-RPC error (what a pruned-state query looks like)
+    fn make_user_error() -> subxt_rpcs::Error {
+        subxt_rpcs::Error::User(subxt_rpcs::UserError {
+            code: -32000,
+            message: "State already discarded for hash".to_string(),
+            data: None,
+        })
+    }
+
     #[test]
     fn test_is_disconnected_error_true() {
         let err = make_disconnected_error();
@@ -237,15 +265,53 @@ mod rpc_error_tests {
         assert!(is_transient_backend_error(&be));
     }
 
+    /// A transport error whose `Display` is not "Request timeout" (connection reset, TLS failure,
+    /// closed socket) is still an upstream blip, so it must be retryable.
     #[test]
-    fn test_is_transient_backend_error_generic_is_not() {
+    fn test_is_transient_backend_error_generic_client_error() {
         let be = subxt::error::BackendError::from(make_generic_error());
+        assert!(is_transient_backend_error(&be));
+    }
+
+    /// Backend-level conditions (e.g. "no available backend") are upstream availability failures.
+    #[test]
+    fn test_is_transient_backend_error_other() {
+        let be = subxt::error::BackendError::other("custom backend failure");
+        assert!(is_transient_backend_error(&be));
+    }
+
+    /// The node answered with a JSON-RPC error: definitive, so not retryable.
+    #[test]
+    fn test_is_transient_backend_error_user_error_is_not() {
+        let be = subxt::error::BackendError::from(make_user_error());
         assert!(!is_transient_backend_error(&be));
     }
 
+    /// A response we could not SCALE-decode is our problem, not a connection problem.
     #[test]
-    fn test_is_transient_backend_error_other_is_not() {
-        let be = subxt::error::BackendError::other("custom backend failure");
+    fn test_is_transient_backend_error_decode_is_not() {
+        let be = subxt::error::BackendError::from(subxt_rpcs::Error::Decode(
+            "bad response bytes".into(),
+        ));
         assert!(!is_transient_backend_error(&be));
+    }
+
+    /// Storage fetch failures inherit the backend classification.
+    #[test]
+    fn test_is_transient_storage_error_follows_backend() {
+        let transient = subxt::error::StorageError::CannotFetchValue(
+            subxt::error::BackendError::from(make_generic_error()),
+        );
+        assert!(is_transient_storage_error(&transient));
+
+        let definitive = subxt::error::StorageError::CannotFetchValue(
+            subxt::error::BackendError::from(make_user_error()),
+        );
+        assert!(!is_transient_storage_error(&definitive));
+
+        // Not a backend-carrying variant at all.
+        assert!(!is_transient_storage_error(
+            &subxt::error::StorageError::NoValueFound
+        ));
     }
 }

--- a/crates/server/src/utils/mod.rs
+++ b/crates/server/src/utils/mod.rs
@@ -49,6 +49,34 @@ pub fn is_backend_disconnected_error(err: &subxt::error::BackendError) -> bool {
     err.is_disconnected_will_reconnect()
 }
 
+/// Whether a `BackendError` is transient (retryable): disconnect, RPC limit, timeout, or
+/// dropped subscription. Anything else is non-retryable.
+pub fn is_transient_backend_error(err: &subxt::error::BackendError) -> bool {
+    use subxt::error::{BackendError, RpcError};
+
+    if err.is_disconnected_will_reconnect() || err.is_rpc_limit_reached() {
+        return true;
+    }
+
+    match err {
+        BackendError::Rpc(RpcError::ClientError(rpc_err)) => is_timeout_error(rpc_err),
+        BackendError::Rpc(RpcError::SubscriptionDropped) => true,
+        _ => false,
+    }
+}
+
+/// Whether a `StorageError` is transient (retryable): a `BackendError`-wrapping variant whose
+/// inner error is itself transient (see [`is_transient_backend_error`]). Used to pick 503 vs 500.
+pub fn is_transient_storage_error(err: &subxt::error::StorageError) -> bool {
+    use subxt::error::StorageError;
+    match err {
+        StorageError::CannotFetchValue(be)
+        | StorageError::CannotIterateValues(be)
+        | StorageError::StreamFailure(be) => is_transient_backend_error(be),
+        _ => false,
+    }
+}
+
 /// Check if an OnlineClientAtBlockError contains a disconnection error.
 ///
 /// The OnlineClientAtBlockError may wrap a BackendError (e.g., in CannotGetBlockHash)
@@ -195,5 +223,29 @@ mod rpc_error_tests {
         let err = make_generic_error();
         let (status, _message) = rpc_error_to_status(&err);
         assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+    }
+
+    #[test]
+    fn test_is_transient_backend_error_disconnect() {
+        let be = subxt::error::BackendError::from(make_disconnected_error());
+        assert!(is_transient_backend_error(&be));
+    }
+
+    #[test]
+    fn test_is_transient_backend_error_timeout() {
+        let be = subxt::error::BackendError::from(make_timeout_error());
+        assert!(is_transient_backend_error(&be));
+    }
+
+    #[test]
+    fn test_is_transient_backend_error_generic_is_not() {
+        let be = subxt::error::BackendError::from(make_generic_error());
+        assert!(!is_transient_backend_error(&be));
+    }
+
+    #[test]
+    fn test_is_transient_backend_error_other_is_not() {
+        let be = subxt::error::BackendError::other("custom backend failure");
+        assert!(!is_transient_backend_error(&be));
     }
 }


### PR DESCRIPTION
### Description

- `GET /v1/accounts/{id}/balance-info` could return `free:0` for a funded account when a `System::Account` read failed transiently (RPC timeout, mid-reconnect blip).
- The read error was swallowed and served as a real `0` with HTTP 200, so two requests at the same block could return different balances.
- A failed read now returns an error instead of a fake `0`: transient failures map to a retryable 503, and a genuinely absent account still returns `0`.
- The same fix is applied to the related account reads (locks, proxy, vesting).

### Changes

- `handlers/runtime_queries/balances.rs`: Add a shared `try_fetch_storage` helper and an `AccountDataError` type. Account/locks/proxy/vesting reads now return an error on a failed fetch instead of empty or zero data. Undecodable account bytes now error instead of becoming `free:0`. A shared `warn_undecodable` helper logs byte length plus a 32-byte hex prefix, wired into all four decoders in this file (`AccountInfo`, `Balances::Locks`, `Proxy::Proxies`, `Vesting::Vesting`), so an unrecognized layout is visible in logs rather than silently emptying a field.
- `handlers/common/accounts/balance_info.rs`: Propagate the account and locks read errors instead of returning a false balance or empty locks. Add `BalanceQueryError::AccountLayoutUnknown(usize)` so the response reports how many bytes failed to decode.
- `handlers/common/accounts/proxy_info.rs`: Propagate the proxy read error instead of showing "no proxies".
- `handlers/common/accounts/vesting_info.rs`: Propagate the vesting read error instead of showing "no vesting".
- `utils/mod.rs`: Add `is_transient_backend_error`, which treats every `BackendError` as retryable (503) by default and excludes only what a retry cannot change: node-returned JSON-RPC errors (`subxt_rpcs::Error::User`), and serialization / deserialization / SCALE-decode / insecure-URL errors. Timeouts, connection resets, TLS failures, closed sockets, `DisconnectedWillReconnect`, `LimitReached`, `SubscriptionDropped` and backend-availability conditions are all retryable. Also add `is_transient_storage_error`, which applies that classification to the three `BackendError`-carrying `StorageError` variants (`CannotFetchValue`, `CannotIterateValues`, `StreamFailure`).
- `handlers/accounts/types.rs`: Map transient storage failures to 503 for all account sub-queries (balance, proxy, vesting, staking) via a shared `storage_query_error` helper, and share the 503 message in one constant.

### Scope

This PR fixes the account balance reads (`System::Account`, `Balances::Locks`, `Proxy::Proxies`, `Vesting::Vesting`). The same swallow-and-default pattern still exists elsewhere and is **not** fixed here:

- `runtime_queries/staking.rs`: `get_reward_destination` falls back to `"Staked"` (line 369), `get_nominations` to `None` (394), `get_slashing_spans_count` to `0` (418), plus the era/exposure helpers (14 `.ok()?` sites between 1449 and 1746).
- `common/accounts/staking_info.rs:213-216`: the `query_claimed_rewards` **call site** discards the error with `.await.ok()`. The function itself returns `Result` and propagates correctly — it is the caller that swallows.
- `runtime_queries/foreign_assets.rs`, `runtime_queries/nomination_pools.rs`, `handlers/pallets/*`.

A blip in those paths can still return `rewardDestination: "Staked"` or `nominations: []` with a 200. Bonded amounts are safe — `get_staking_ledger` already returns `Result` and `staking_info.rs:210` propagates it. Follow-up issue: #387

### Testing

- New tests: transient fetch error, undecodable bytes, the backend-error classifier (including node JSON-RPC and SCALE-decode errors staying non-retryable), storage errors inheriting the backend verdict, handler-level status mapping (non-timeout transport failure → 503, node JSON-RPC error → 500), and the decode error carrying its byte count into the rendered message.
- `cargo test --workspace --exclude integration_tests` — 737 passed, 0 failed.
- `cargo fmt --check` and `cargo clippy --workspace --all-features -- -D warnings` both clean.

### Note for the integrator

- Transient blips now return 503, not 200 with `free:0`. Clients should treat 503 as "retry", not as balance = 0.
- Node-returned JSON-RPC errors stay 500, deliberately. The node *answered* there — e.g. `-32000 State already discarded` for an `at=` inside pruned state — and a 503 would tell clients to retry something that can never succeed.
- `?useRcBlock=true` returns an array of results, one per Asset Hub block in the relay-chain block. Those are gathered with `try_join_all`, so a storage failure on any one AH block now fails the whole request (503 if transient) instead of contributing a fabricated `free: 0` entry. This is intentional — a wrong entry is worse than a retryable failure — but it is a behaviour change for `useRcBlock` clients. The same applies to the proxy, vesting and staking `useRcBlock` paths.