### PR TITLE
test: fix 4 failing accounts integration tests and run the suite in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,13 @@ jobs:
           TEST_DELAY_MS: 2000
         timeout-minutes: 15
 
+      - name: Run accounts integration tests (Asset Hub Polkadot)
+        run: cargo test --package integration_tests --test accounts
+        env:
+          API_URL: http://localhost:8080
+          RUST_LOG: info
+        timeout-minutes: 10
+
       - name: Stop Asset Hub Polkadot server
         if: always()
         run: |

--- a/crates/integration_tests/README.md
+++ b/crates/integration_tests/README.md
@@ -29,6 +29,21 @@ Regression tests using pre-recorded fixtures. These ensure API responses remain 
 - Tests specific historical blocks (e.g., block 1,000,000)
 - Ignores time-varying fields (timestamps, etc.)
 
+### 4. Accounts Tests (`tests/accounts/`)
+
+Endpoint-by-endpoint tests for `/accounts/*` and `/rc/accounts/*`, one submodule per endpoint.
+Runs against Asset Hub Polkadot.
+
+- Response structure, filters, hex and SS58 addresses, `useRcBlock`
+- Error handling for invalid addresses and missing required query parameters
+- A few tests compare against Sidecar fixtures in `tests/fixtures/asset-hub-polkadot/`
+
+### Suites not yet run in CI
+
+`capabilities`, `chain_config`, `coretime`, `relay_chain_connection` and `use_rc_block` exist as
+test targets but are not wired into `ci.yml`. Each needs its own chain or server setup before it
+can be gated on.
+
 ## Running Tests
 
 ### Prerequisites
@@ -52,6 +67,7 @@ cargo run --release --bin polkadot-rest-api
 cargo test --package integration_tests --test historical
 cargo test --package integration_tests --test latest
 cargo test --package integration_tests --test basic
+cargo test --package integration_tests --test accounts   # Asset Hub Polkadot
 
 # Run a specific chain's tests
 cargo test --package integration_tests --test historical test_historical_polkadot

--- a/crates/integration_tests/README.md
+++ b/crates/integration_tests/README.md
@@ -42,7 +42,7 @@ Runs against Asset Hub Polkadot.
 
 `capabilities`, `chain_config`, `coretime`, `relay_chain_connection` and `use_rc_block` exist as
 test targets but are not wired into `ci.yml`. Each needs its own chain or server setup before it
-can be gated on.
+can be gated on. Tracked in [#394](https://github.com/paritytech/polkadot-rest-api/issues/394).
 
 ## Running Tests
 

--- a/crates/integration_tests/tests/accounts/asset_approvals.rs
+++ b/crates/integration_tests/tests/accounts/asset_approvals.rs
@@ -281,9 +281,10 @@ async fn test_asset_approvals_missing_required_params() -> Result<()> {
         .and_then(|o| o.get("error"))
         .and_then(|e| e.as_str())
         .expect("Response should have an 'error' string field");
+    // Serde stops at the first missing field, so only `assetId` is named here.
     assert!(
-        error_both.contains("assetId") && error_both.contains("delegate"),
-        "Error should mention both missing fields, got: {}",
+        error_both.contains("assetId"),
+        "Error should name the first missing field, got: {}",
         error_both
     );
     println!(

--- a/crates/integration_tests/tests/accounts/asset_balances.rs
+++ b/crates/integration_tests/tests/accounts/asset_balances.rs
@@ -117,8 +117,10 @@ async fn test_asset_balances_comparison() -> Result<()> {
 
     let account_id = test_accounts::ASSET_HUB_ACCOUNT;
     let block_number = 10260000;
+    // The Sidecar fixture includes zero balances; this endpoint hides them unless
+    // `showEmpty=true`. See docs/guides/MIGRATION.md.
     let endpoint = format!(
-        "/accounts/{}/asset-balances?at={}",
+        "/accounts/{}/asset-balances?at={}&showEmpty=true",
         account_id, block_number
     );
 

--- a/crates/integration_tests/tests/accounts/foreign_asset_balances.rs
+++ b/crates/integration_tests/tests/accounts/foreign_asset_balances.rs
@@ -171,7 +171,7 @@ async fn test_foreign_asset_balances_with_filter() -> Result<()> {
     // The default test account holds no foreign assets, which made this test vacuous.
     let account_id = test_accounts::ASSET_HUB_FOREIGN_ASSET_HOLDER;
     let block_number = 10260000;
-    // Request spells it `chain_id`; the response returns `chainId`. Not a typo, see #391.
+    // Request spells it `chain_id`; the response returns `chainId`. Not a typo, see #392.
     let multi_location =
         r#"{"parents":"2","interior":{"X1":[{"GlobalConsensus":{"Ethereum":{"chain_id":"1"}}}]}}"#;
     let endpoint = format!(

--- a/crates/integration_tests/tests/accounts/foreign_asset_balances.rs
+++ b/crates/integration_tests/tests/accounts/foreign_asset_balances.rs
@@ -168,12 +168,15 @@ async fn test_foreign_asset_balances_at_specific_block() -> Result<()> {
 async fn test_foreign_asset_balances_with_filter() -> Result<()> {
     let local_client = get_client().await?;
 
-    let account_id = test_accounts::ASSET_HUB_ACCOUNT;
+    // The default test account holds no foreign assets, which made this test vacuous.
+    let account_id = test_accounts::ASSET_HUB_FOREIGN_ASSET_HOLDER;
+    let block_number = 10260000;
+    // Request spells it `chain_id`; the response returns `chainId`. Not a typo, see #391.
     let multi_location =
-        r#"{"parents":"2","interior":{"X1":{"GlobalConsensus":{"Ethereum":{"chainId":"1"}}}}}"#;
+        r#"{"parents":"2","interior":{"X1":[{"GlobalConsensus":{"Ethereum":{"chain_id":"1"}}}]}}"#;
     let endpoint = format!(
-        "/accounts/{}/foreign-asset-balances?foreignAssets[]={}",
-        account_id, multi_location
+        "/accounts/{}/foreign-asset-balances?at={}&foreignAssets[]={}",
+        account_id, block_number, multi_location
     );
 
     println!(
@@ -209,6 +212,11 @@ async fn test_foreign_asset_balances_with_filter() -> Result<()> {
         "  {} Response contains {} foreign asset(s) after filtering",
         "✓".green(),
         foreign_assets.len()
+    );
+
+    assert!(
+        !foreign_assets.is_empty(),
+        "Filter returned no foreign assets, so nothing below is actually verified"
     );
 
     for asset in foreign_assets {

--- a/crates/integration_tests/tests/accounts/mod.rs
+++ b/crates/integration_tests/tests/accounts/mod.rs
@@ -72,6 +72,10 @@ pub mod test_accounts {
     /// Asset Hub Polkadot address with known assets
     pub const ASSET_HUB_ACCOUNT: &str = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY";
 
+    /// Hydration's sovereign account on Asset Hub Polkadot; holds Ethereum-backed foreign assets
+    pub const ASSET_HUB_FOREIGN_ASSET_HOLDER: &str =
+        "13cKp89Uh2yWgTG28JA1QEvPUMjEPKejqkjHKf9zqLiFKjH6";
+
     // =============================================================================================
     // Special Purpose Addresses
     // =============================================================================================

--- a/crates/integration_tests/tests/accounts/pool_asset_approvals.rs
+++ b/crates/integration_tests/tests/accounts/pool_asset_approvals.rs
@@ -257,9 +257,10 @@ async fn test_pool_asset_approvals_missing_required_params() -> Result<()> {
         .and_then(|o| o.get("error"))
         .and_then(|e| e.as_str())
         .expect("Response should have an 'error' string field");
+    // Serde stops at the first missing field, so only `assetId` is named here.
     assert!(
-        error_both.contains("assetId") && error_both.contains("delegate"),
-        "Error should mention both missing fields, got: {}",
+        error_both.contains("assetId"),
+        "Error should name the first missing field, got: {}",
         error_both
     );
     println!(

--- a/crates/integration_tests/tests/fixtures/asset-hub-polkadot/accounts_asset_balances_alice_10260000.json
+++ b/crates/integration_tests/tests/fixtures/asset-hub-polkadot/accounts_asset_balances_alice_10260000.json
@@ -1,0 +1,3716 @@
+{
+  "at": {
+    "hash": "0xec77b29816dec211e0565fdbdee1e29a7fc482f6f19e6e44ecdebc37545a155e",
+    "height": "10260000"
+  },
+  "assets": [
+    {
+      "assetId": "22222005",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000074",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "9999",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222087",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090142",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "100",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000133",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222041",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "56",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000055",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000121",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000122",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "482",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222025",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "81",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000050",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000323",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "200",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000138",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000254",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000030",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000153",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "123",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "52",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000067",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "9000",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2222",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000284",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "58",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "222",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "69420",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000038",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000012",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000003",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "47",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000075",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000128",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000268",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000083",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000301",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "25518",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000311",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000015",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "420",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "0",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000059",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "110",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "10",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1001",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222028",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000255",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222079",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000148",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000114",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000285",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090110",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222024",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "256",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000006",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000042",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222070",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222019",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090130",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "108",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1111",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "202406",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222084",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222008",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000160",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "300",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000292",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222046",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "4",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222043",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "48",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000051",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000245",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000000",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222064",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "21",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000288",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000306",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "333",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222050",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000269",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "28",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090109",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "7006",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090138",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000261",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "67",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000196",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090140",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "999",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "30",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000010",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "39",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000161",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "10101",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000319",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000200",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "101",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "38",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090147",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "46",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000092",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090133",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222036",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000002",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "99",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "34",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000147",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000209",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222058",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222002",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000018",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000304",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000103",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000289",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000022",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000089",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090114",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "16",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "11",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000335",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000076",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000235",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222051",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000117",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000260",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000322",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000299",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000313",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000264",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222020",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000251",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222073",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222074",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000300",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090111",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000142",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "30035",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222062",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "75",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090119",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "111",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090121",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000151",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222075",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000110",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222022",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000065",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "122",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "66",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000017",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000137",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000040",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000233",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000279",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000207",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000231",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000130",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "555",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000242",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2828",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "57",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222021",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000105",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222009",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "14",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "6",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "65454",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000332",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000159",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "669",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000249",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "8889",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "19",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "8886",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000156",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "42069",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222068",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000262",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000283",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000127",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090143",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000078",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090117",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000305",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090112",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000095",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090131",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1107",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1212",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000145",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000085",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000008",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222078",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000088",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "73",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000069",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "77",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "35",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222029",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "9002",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000037",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000021",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000086",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000107",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "36",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "420666",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222053",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1747",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000124",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000111",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000199",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000281",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "31",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000031",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000162",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000267",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "33",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090115",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000063",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000113",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000237",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "301",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000144",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000039",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000257",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090122",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2020",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000302",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "41",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "5318008",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000318",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000139",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000072",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000073",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000275",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "71",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "37362",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000023",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000239",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "44",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000297",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000328",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222077",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000016",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "15",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "9202",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000093",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000084",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222013",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222010",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222071",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000032",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000253",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000054",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "78",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000058",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000274",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090128",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000240",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "61",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "40",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090144",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000131",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000025",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "789",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090106",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000136",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "3164",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000325",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1828",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000035",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090116",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222031",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222014",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1810",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090129",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "678",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222034",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000331",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "74",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000317",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000143",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "70",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000314",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "13",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000195",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000066",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000327",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090136",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "32",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222035",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "82",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222065",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2106",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "9527",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000154",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "27",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "89",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000273",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000013",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222001",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000294",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222042",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222018",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000019",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000080",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "49",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222044",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "868367",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "5361",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000048",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000238",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000116",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2829",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000296",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000091",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000082",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222037",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "53",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "29",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000135",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1970",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "42",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000259",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222059",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000329",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000248",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000108",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000020",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "43",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000282",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "7777777",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000310",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2001",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000053",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222003",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222039",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "5",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "18",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000134",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "83",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "7",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000146",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222055",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000033",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "4242",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "26",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000118",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1010",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222072",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000309",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "201",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1984",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000246",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000028",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000277",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000096",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090104",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222082",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000243",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000112",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090103",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090118",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222085",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000102",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000291",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000004",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000149",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000141",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090124",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "690",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222048",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "33441",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000052",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000293",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "777777",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "72",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "79",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222038",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000303",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000123",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "777",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "86",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090113",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222076",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000101",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000046",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000158",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "567",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000295",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "457",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "68",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "54",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222023",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222088",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222066",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "181",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000045",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222027",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "9003",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222033",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000119",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1313",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090120",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "24",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000290",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090123",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000115",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000043",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2023",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222067",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "90",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000081",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000098",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222017",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "80",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000026",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000232",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000333",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090139",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000152",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000007",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1864",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "8",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000176",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000197",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "45",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000034",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000321",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000079",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222080",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000125",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222057",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "10000",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "8277",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000163",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000234",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "59",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000071",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2820",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000230",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000099",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000315",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000241",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090125",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222069",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000308",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222007",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000330",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "51",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090135",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000041",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1234",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "404",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222016",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090134",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1000",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222049",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000286",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000252",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000266",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000106",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "8008",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090146",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000044",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000236",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000049",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222047",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000047",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222030",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000324",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000109",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000256",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222086",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "60",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090126",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000094",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000280",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1992",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000068",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000009",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090145",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "6666",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000070",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000057",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2121",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000157",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000011",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1024",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000060",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000312",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090132",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000062",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "12",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "31337",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "97",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "12345",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000320",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000177",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000097",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222000",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090149",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222045",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000287",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2000",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000164",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000132",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "3",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222056",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000244",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "6969",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "55",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1983",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000027",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222054",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1337",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000263",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "666",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "88",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "8888",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "112233",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "17",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "63",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1180",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000265",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1148",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000024",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "25",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090108",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000064",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000090",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090137",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000005",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "69",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000077",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222032",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000298",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000029",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000307",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000198",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222015",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000087",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "23",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090105",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000104",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000056",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "37",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090141",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000334",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "5417",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "65",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000272",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000247",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "9001",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000166",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000120",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "7151",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "149",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2025",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "1980",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000250",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000316",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "91",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000179",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000276",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "77777",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090107",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000326",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222061",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000271",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222006",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "64",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "4157",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090148",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000100",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222040",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000155",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000270",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222026",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000278",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "6594",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000140",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "660301",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000208",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "9",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "862812",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "888",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2024",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222060",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222081",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222011",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "20090127",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000014",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222004",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "62",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222012",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000165",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000258",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000036",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2230",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000129",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222063",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "22222052",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "92",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000150",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000178",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "50000061",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    },
+    {
+      "assetId": "2203",
+      "balance": "0",
+      "isFrozen": false,
+      "isSufficient": false
+    }
+  ]
+}


### PR DESCRIPTION
Closes #391

### Description

`cargo test --package integration_tests --test accounts` failed 4 of its 136 tests against Asset Hub Polkadot. All 4 were test-side problems, not API regressions. They went unnoticed because `ci.yml` never ran this suite, so `/accounts/*` had no CI coverage at all.

This fixes the 4 tests and adds the suite to the Asset Hub Polkadot job.

### Changes

* `foreign_asset_balances.rs`: the filter test sent an outdated XCM location and got a 400. `X1` takes a 1 element array since XCM v4, and the request deserializer expects `chain_id`. The test also ran against an account holding no foreign assets, so its assertion loop never executed. It now runs against a sovereign account that holds Ethereum backed foreign assets at a pinned block, and asserts the result is non empty.
* `asset_approvals.rs`, `pool_asset_approvals.rs`: both asserted the error names `assetId` and `delegate`. Serde stops at the first missing field, so this could never pass. They now assert on `assetId` only, matching the single field case a few lines below in each file that already passed.
* `asset_balances.rs`: the fixture `accounts_asset_balances_alice_10260000.json` was missing from the repo. Regenerated from `substrate-api-sidecar` v20.14.1. The test now sends `showEmpty=true`, which is required for the two to be comparable: Sidecar lists every registered asset, while this endpoint drops zero balances by default (see `docs/guides/MIGRATION.md`).
* `mod.rs`: new `ASSET_HUB_FOREIGN_ASSET_HOLDER` constant.
* `ci.yml`: run `--test accounts` in the Asset Hub Polkadot job, reusing the server already started there.
* `README.md`: document the accounts suite and list the 5 test targets still not in CI, pointing at #394.

### Testing

Before:

```
test result: FAILED. 132 passed; 4 failed
```

After:

```
test result: ok. 136 passed; 0 failed
```

Reproduced with:

```
cargo build --release --package server
./scripts/start-server-with-fallback.sh asset-hub-polkadot
API_URL=http://localhost:8080 cargo test --package integration_tests --test accounts
```

Both new assertions were checked against the failure they guard. Pointing the filter test back at the old account fails on the non empty assertion. Dropping `showEmpty=true` fails the comparison with 619 differences.

`cargo fmt --all -- --check` and `cargo clippy --workspace --all-features --all-targets -- -D warnings` are clean.

### Notes

The API emits `chainId` but only accepts `chain_id`, so a multilocation copied from a response cannot be used as a filter. That is #392, not fixed here. The test uses the accepted spelling as a workaround. If #392 lands first, the test can go back to `chainId`.

The fixture holds 618 entries, all zero balances, so it checks asset id enumeration, ordering and field shape against Sidecar but does not exercise a non zero balance.

This wires the accounts suite only. The other 5 test targets (`capabilities`, `chain_config`, `coretime`, `relay_chain_connection`, `use_rc_block`) are still never run in CI, which is #394. They each need their own chain or server setup, so they are left for separate changes.